### PR TITLE
Feat/aufstieg

### DIFF
--- a/drizzle/0022_spotty_darwin.sql
+++ b/drizzle/0022_spotty_darwin.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "group" ADD COLUMN "tier" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "participant" ADD COLUMN "exercise_promotion_right" boolean;

--- a/drizzle/0023_silent_wither.sql
+++ b/drizzle/0023_silent_wither.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "group" ALTER COLUMN "tier" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "group" ALTER COLUMN "tier" DROP NOT NULL;

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1893 @@
+{
+  "id": "f4536071-8b27-4acd-be62-c1f231910a29",
+  "prevId": "2ff47026-c68d-4964-9827-060f1d951216",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "white_player_id": {
+          "name": "white_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "black_player_id": {
+          "name": "black_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pgn_id": {
+          "name": "pgn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_number": {
+          "name": "board_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_postponement": {
+      "name": "game_postponement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_postponement_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponing_participant_id": {
+          "name": "postponing_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponed_by_profile_id": {
+          "name": "postponed_by_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group": {
+      "name": "group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "group_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_tournament_id_group_number_pk": {
+          "name": "group_tournament_id_group_number_pk",
+          "columns": [
+            "tournament_id",
+            "group_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.juror": {
+      "name": "juror",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "juror_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "juror_tournament_id_profile_id_unique": {
+          "name": "juror_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_match_entering_helper": {
+      "name": "group_match_entering_helper",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_entering_helper_id": {
+          "name": "match_entering_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_match_entering_helper_group_id_match_entering_helper_id_pk": {
+          "name": "group_match_entering_helper_group_id_match_entering_helper_id_pk",
+          "columns": [
+            "group_id",
+            "match_entering_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_entering_helper": {
+      "name": "match_entering_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "match_entering_helper_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_groups_to_enter": {
+          "name": "number_of_groups_to_enter",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_entering_helper_tournament_id_profile_id_unique": {
+          "name": "match_entering_helper_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday": {
+      "name": "matchday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "matchday_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_week_id": {
+          "name": "tournament_week_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_needed": {
+          "name": "referee_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_game": {
+      "name": "matchday_game",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_game_matchday_id_game_id_pk": {
+          "name": "matchday_game_matchday_id_game_id_pk",
+          "columns": [
+            "matchday_id",
+            "game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_referee": {
+      "name": "matchday_referee",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_id": {
+          "name": "referee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_referee_matchday_id_referee_id_pk": {
+          "name": "matchday_referee_matchday_id_referee_id_pk",
+          "columns": [
+            "matchday_id",
+            "referee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_setup_helper": {
+      "name": "matchday_setup_helper",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_helper_id": {
+          "name": "setup_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_setup_helper_matchday_id_setup_helper_id_pk": {
+          "name": "matchday_setup_helper_matchday_id_setup_helper_id_pk",
+          "columns": [
+            "matchday_id",
+            "setup_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant": {
+      "name": "participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "participant_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chess_club": {
+          "name": "chess_club",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'m'"
+        },
+        "dwz_rating": {
+          "name": "dwz_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_rating": {
+          "name": "fide_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_club_id": {
+          "name": "zps_club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_player_id": {
+          "name": "zps_player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_days": {
+          "name": "secondary_match_days",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "not_available_days": {
+          "name": "not_available_days",
+          "type": "date[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_fee_payed": {
+          "name": "entry_fee_payed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exercise_promotion_right": {
+          "name": "exercise_promotion_right",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participant_tournament_id_profile_id_unique": {
+          "name": "participant_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_group": {
+      "name": "participant_group",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_position": {
+          "name": "group_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "participant_group_group_id_participant_id_group_position_pk": {
+          "name": "participant_group_group_id_participant_id_group_position_pk",
+          "columns": [
+            "group_id",
+            "participant_id",
+            "group_position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pgn": {
+      "name": "pgn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pgn_game_id_unique": {
+          "name": "pgn_game_id_unique",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pgn_game_id_game_id_fk": {
+          "name": "pgn_game_id_game_id_fk",
+          "tableFrom": "pgn",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "profile_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_title": {
+          "name": "academic_title",
+          "type": "academic_title",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_email_unique": {
+          "name": "profile_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referee": {
+      "name": "referee",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "referee_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "referee_tournament_id_profile_id_unique": {
+          "name": "referee_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_helper": {
+      "name": "setup_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "setup_helper_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "setup_helper_tournament_id_profile_id_unique": {
+          "name": "setup_helper_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament": {
+      "name": "tournament",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_rounds": {
+          "name": "number_of_rounds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_registration_date": {
+          "name": "end_registration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_announcement_offset_days": {
+          "name": "group_announcement_offset_days",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_limit": {
+          "name": "time_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_clocks_digital": {
+          "name": "all_clocks_digital",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tie_break_method": {
+          "name": "tie_break_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "software": {
+          "name": "software",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "tournament_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registration'"
+        },
+        "game_start_time": {
+          "name": "game_start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'19:00:00'"
+        },
+        "organizer_profile_id": {
+          "name": "organizer_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "one_tournament_in_registration": {
+          "name": "one_tournament_in_registration",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tournament\".\"stage\" = 'registration'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_slug_unique": {
+          "name": "tournament_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_week": {
+      "name": "tournament_week",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_week_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_week_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "week_number": {
+          "name": "week_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainer": {
+      "name": "trainer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "trainer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trainer_tournament_id_profile_id_unique": {
+          "name": "trainer_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.academic_title": {
+      "name": "academic_title",
+      "schema": "public",
+      "values": [
+        "Dr."
+      ]
+    },
+    "public.result": {
+      "name": "result",
+      "schema": "public",
+      "values": [
+        "1:0",
+        "0:1",
+        "½-½",
+        "+:-",
+        "-:+",
+        "-:-",
+        "0-½",
+        "½-0"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "m",
+        "f"
+      ]
+    },
+    "public.match_day": {
+      "name": "match_day",
+      "schema": "public",
+      "values": [
+        "tuesday",
+        "thursday",
+        "friday"
+      ]
+    },
+    "public.tournament_stage": {
+      "name": "tournament_stage",
+      "schema": "public",
+      "values": [
+        "registration",
+        "running",
+        "done"
+      ]
+    },
+    "public.tournament_week_status": {
+      "name": "tournament_week_status",
+      "schema": "public",
+      "values": [
+        "regular",
+        "catch-up"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0023_snapshot.json
+++ b/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,1892 @@
+{
+  "id": "5ef7ef92-fa74-4501-8171-6309eeb7ebcc",
+  "prevId": "f4536071-8b27-4acd-be62-c1f231910a29",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "white_player_id": {
+          "name": "white_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "black_player_id": {
+          "name": "black_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pgn_id": {
+          "name": "pgn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_number": {
+          "name": "board_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_postponement": {
+      "name": "game_postponement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_postponement_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponing_participant_id": {
+          "name": "postponing_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponed_by_profile_id": {
+          "name": "postponed_by_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group": {
+      "name": "group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "group_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_tournament_id_group_number_pk": {
+          "name": "group_tournament_id_group_number_pk",
+          "columns": [
+            "tournament_id",
+            "group_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.juror": {
+      "name": "juror",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "juror_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "juror_tournament_id_profile_id_unique": {
+          "name": "juror_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_match_entering_helper": {
+      "name": "group_match_entering_helper",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_entering_helper_id": {
+          "name": "match_entering_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_match_entering_helper_group_id_match_entering_helper_id_pk": {
+          "name": "group_match_entering_helper_group_id_match_entering_helper_id_pk",
+          "columns": [
+            "group_id",
+            "match_entering_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_entering_helper": {
+      "name": "match_entering_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "match_entering_helper_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_groups_to_enter": {
+          "name": "number_of_groups_to_enter",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_entering_helper_tournament_id_profile_id_unique": {
+          "name": "match_entering_helper_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday": {
+      "name": "matchday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "matchday_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_week_id": {
+          "name": "tournament_week_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_needed": {
+          "name": "referee_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_game": {
+      "name": "matchday_game",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_game_matchday_id_game_id_pk": {
+          "name": "matchday_game_matchday_id_game_id_pk",
+          "columns": [
+            "matchday_id",
+            "game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_referee": {
+      "name": "matchday_referee",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_id": {
+          "name": "referee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_referee_matchday_id_referee_id_pk": {
+          "name": "matchday_referee_matchday_id_referee_id_pk",
+          "columns": [
+            "matchday_id",
+            "referee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_setup_helper": {
+      "name": "matchday_setup_helper",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_helper_id": {
+          "name": "setup_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_setup_helper_matchday_id_setup_helper_id_pk": {
+          "name": "matchday_setup_helper_matchday_id_setup_helper_id_pk",
+          "columns": [
+            "matchday_id",
+            "setup_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant": {
+      "name": "participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "participant_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chess_club": {
+          "name": "chess_club",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'m'"
+        },
+        "dwz_rating": {
+          "name": "dwz_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_rating": {
+          "name": "fide_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_club_id": {
+          "name": "zps_club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_player_id": {
+          "name": "zps_player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_days": {
+          "name": "secondary_match_days",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "not_available_days": {
+          "name": "not_available_days",
+          "type": "date[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_fee_payed": {
+          "name": "entry_fee_payed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exercise_promotion_right": {
+          "name": "exercise_promotion_right",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participant_tournament_id_profile_id_unique": {
+          "name": "participant_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_group": {
+      "name": "participant_group",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_position": {
+          "name": "group_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "participant_group_group_id_participant_id_group_position_pk": {
+          "name": "participant_group_group_id_participant_id_group_position_pk",
+          "columns": [
+            "group_id",
+            "participant_id",
+            "group_position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pgn": {
+      "name": "pgn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pgn_game_id_unique": {
+          "name": "pgn_game_id_unique",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pgn_game_id_game_id_fk": {
+          "name": "pgn_game_id_game_id_fk",
+          "tableFrom": "pgn",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "profile_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_title": {
+          "name": "academic_title",
+          "type": "academic_title",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_email_unique": {
+          "name": "profile_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referee": {
+      "name": "referee",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "referee_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "referee_tournament_id_profile_id_unique": {
+          "name": "referee_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_helper": {
+      "name": "setup_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "setup_helper_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "setup_helper_tournament_id_profile_id_unique": {
+          "name": "setup_helper_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament": {
+      "name": "tournament",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_rounds": {
+          "name": "number_of_rounds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_registration_date": {
+          "name": "end_registration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_announcement_offset_days": {
+          "name": "group_announcement_offset_days",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_limit": {
+          "name": "time_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_clocks_digital": {
+          "name": "all_clocks_digital",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tie_break_method": {
+          "name": "tie_break_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "software": {
+          "name": "software",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "tournament_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registration'"
+        },
+        "game_start_time": {
+          "name": "game_start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'19:00:00'"
+        },
+        "organizer_profile_id": {
+          "name": "organizer_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "one_tournament_in_registration": {
+          "name": "one_tournament_in_registration",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tournament\".\"stage\" = 'registration'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_slug_unique": {
+          "name": "tournament_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_week": {
+      "name": "tournament_week",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_week_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_week_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "week_number": {
+          "name": "week_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainer": {
+      "name": "trainer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "trainer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trainer_tournament_id_profile_id_unique": {
+          "name": "trainer_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.academic_title": {
+      "name": "academic_title",
+      "schema": "public",
+      "values": [
+        "Dr."
+      ]
+    },
+    "public.result": {
+      "name": "result",
+      "schema": "public",
+      "values": [
+        "1:0",
+        "0:1",
+        "½-½",
+        "+:-",
+        "-:+",
+        "-:-",
+        "0-½",
+        "½-0"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "m",
+        "f"
+      ]
+    },
+    "public.match_day": {
+      "name": "match_day",
+      "schema": "public",
+      "values": [
+        "tuesday",
+        "thursday",
+        "friday"
+      ]
+    },
+    "public.tournament_stage": {
+      "name": "tournament_stage",
+      "schema": "public",
+      "values": [
+        "registration",
+        "running",
+        "done"
+      ]
+    },
+    "public.tournament_week_status": {
+      "name": "tournament_week_status",
+      "schema": "public",
+      "values": [
+        "regular",
+        "catch-up"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1781708091478,
       "tag": "0021_lethal_landau",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1782643511298,
+      "tag": "0022_spotty_darwin",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1782643511298,
       "tag": "0022_spotty_darwin",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1782664183364,
+      "tag": "0023_silent_wither",
+      "breakpoints": true
     }
   ]
 }

--- a/src/actions/group.ts
+++ b/src/actions/group.ts
@@ -28,6 +28,13 @@ export const saveGroups = action(
       return { error: "Bitte für jede Gruppe eine Stufe angeben." };
     }
 
+    const aGroupCount = groupsData.filter(
+      (g) => !g.isDeleted && g.tier === 0,
+    ).length;
+    if (aGroupCount > 1) {
+      return { error: "Es darf nur eine Gruppe mit Stufe A geben." };
+    }
+
     const groupsToDelete = groupsData.filter((g) => g.isDeleted);
     const groupsToInsert = groupsData.filter((g) => g.isNew && !g.isDeleted);
     const groupsToUpdate = groupsData.filter((g) => !g.isNew && !g.isDeleted);

--- a/src/actions/group.ts
+++ b/src/actions/group.ts
@@ -21,6 +21,13 @@ export const saveGroups = action(
     const session = await authWithRedirect();
     invariant(session?.user.role === "admin", "Unauthorized");
 
+    const groupWithoutTier = groupsData.find(
+      (g) => !g.isDeleted && g.tier == null,
+    );
+    if (groupWithoutTier) {
+      return { error: "Bitte für jede Gruppe eine Stufe angeben." };
+    }
+
     const groupsToDelete = groupsData.filter((g) => g.isDeleted);
     const groupsToInsert = groupsData.filter((g) => g.isNew && !g.isDeleted);
     const groupsToUpdate = groupsData.filter((g) => !g.isNew && !g.isDeleted);
@@ -88,6 +95,7 @@ async function updateGroup(
     .set({
       groupName: groupData.groupName,
       groupNumber: groupData.groupNumber,
+      tier: groupData.tier ?? 0,
       dayOfWeek: groupData.dayOfWeek,
     })
     .where(eq(group.id, groupData.id));
@@ -205,6 +213,7 @@ async function insertGroup(
       tournamentId,
       groupName: data.groupName,
       groupNumber: data.groupNumber,
+      tier: data.tier ?? 0,
       dayOfWeek: data.dayOfWeek,
     })
     .returning();

--- a/src/actions/group.ts
+++ b/src/actions/group.ts
@@ -102,7 +102,7 @@ async function updateGroup(
     .set({
       groupName: groupData.groupName,
       groupNumber: groupData.groupNumber,
-      tier: groupData.tier ?? 0,
+      tier: groupData.tier,
       dayOfWeek: groupData.dayOfWeek,
     })
     .where(eq(group.id, groupData.id));
@@ -220,7 +220,7 @@ async function insertGroup(
       tournamentId,
       groupName: data.groupName,
       groupNumber: data.groupNumber,
-      tier: data.tier ?? 0,
+      tier: data.tier,
       dayOfWeek: data.dayOfWeek,
     })
     .returning();

--- a/src/actions/participant.ts
+++ b/src/actions/participant.ts
@@ -9,6 +9,7 @@ import { authWithRedirect } from "@/auth/utils";
 import { getTournamentById } from "@/db/repositories/tournament";
 import { getProfileByUserId } from "@/db/repositories/profile";
 import { getParticipantsWithZpsIdsByTournamentId } from "@/db/repositories/participant";
+import { getPromotionEligibility } from "@/services/promotion";
 import { and, eq } from "drizzle-orm";
 import { DEFAULT_CLUB_LABEL } from "@/constants/constants";
 import { revalidatePath } from "next/cache";
@@ -39,6 +40,11 @@ export async function createParticipant(
   const currentProfile = await getProfileByUserId(session.user.id);
   invariant(currentProfile, "Profile not found");
 
+  const promotionEligibility = await getPromotionEligibility(currentProfile.id);
+  const exercisePromotionRight = promotionEligibility
+    ? (data.exercisePromotionRight ?? false)
+    : null;
+
   await db
     .insert(participant)
     .values({
@@ -57,6 +63,7 @@ export async function createParticipant(
       zpsClubId: data.zpsClub,
       zpsPlayerId: data.zpsPlayer,
       entryFeePayed: data.chessClubType === "other" ? false : null,
+      exercisePromotionRight,
     })
     .onConflictDoUpdate({
       target: [participant.tournamentId, participant.profileId],
@@ -74,6 +81,7 @@ export async function createParticipant(
         zpsClubId: data.zpsClub,
         zpsPlayerId: data.zpsPlayer,
         entryFeePayed: data.chessClubType === "other" ? false : null,
+        exercisePromotionRight,
       },
     });
 }

--- a/src/actions/tournament.ts
+++ b/src/actions/tournament.ts
@@ -14,6 +14,7 @@ import { matchday } from "@/db/schema/matchday";
 import { isHoliday } from "@/lib/holidays";
 import { getCurrentLocalDateTime } from "@/lib/date";
 import {
+  getActiveTournament,
   getOpenRegistrationTournament,
   getTournamentBySlug,
 } from "@/db/repositories/tournament";
@@ -31,11 +32,11 @@ export async function createTournament(
     return { error: `Der Slug "${data.slug}" ist bereits vergeben.` };
   }
 
-  const openRegistration = await getOpenRegistrationTournament();
-  if (openRegistration) {
+  const activeTournament = await getActiveTournament();
+  if (activeTournament) {
     return {
       error:
-        "Es gibt bereits ein Turnier in der Anmeldephase. Schließe dessen Anmeldung, bevor du ein neues Turnier anlegst.",
+        "Es gibt noch ein nicht abgeschlossenes Turnier. Alle bestehenden Turniere müssen abgeschlossen sein, bevor du ein neues Turnier anlegst.",
     };
   }
 

--- a/src/app/(main)/turniere/[slug]/admin/tournament/page.tsx
+++ b/src/app/(main)/turniere/[slug]/admin/tournament/page.tsx
@@ -10,7 +10,10 @@ import {
 } from "@/components/ui/collapsible";
 import { ChevronDownIcon } from "lucide-react";
 import { getProfilesByUserRole } from "@/db/repositories/profile";
-import { getTournamentBySlug } from "@/db/repositories/tournament";
+import {
+  getActiveTournament,
+  getTournamentBySlug,
+} from "@/db/repositories/tournament";
 import {
   getGroupsWithParticipantsByTournamentId,
   getGroupsByTournamentId,
@@ -42,6 +45,7 @@ export default async function Page({
 
 async function ManageTournament({ tournament }: { tournament?: Tournament }) {
   const adminProfiles = await getProfilesByUserRole("admin");
+  const activeTournament = await getActiveTournament();
   const groups = tournament
     ? await getGroupsWithParticipantsByTournamentId(tournament.id)
     : [];
@@ -74,6 +78,7 @@ async function ManageTournament({ tournament }: { tournament?: Tournament }) {
             adminProfiles={adminProfiles}
             tournament={tournament}
             tournamentWeeks={tournamentWeeks}
+            activeTournamentName={activeTournament?.name}
           />
         </CollapsibleContent>
       </Collapsible>

--- a/src/app/(main)/turniere/[slug]/admin/tournament/page.tsx
+++ b/src/app/(main)/turniere/[slug]/admin/tournament/page.tsx
@@ -3,21 +3,12 @@ import { TournamentStageManager } from "@/components/admin/tournament/tournament
 import TournamentDetailsManager from "@/components/admin/tournament/tournament-details-manager";
 import { AssignmentMailButton } from "@/components/admin/tournament/assignment-mail-button";
 import { GroupMailButton } from "@/components/admin/tournament/group-mail-button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { ChevronDownIcon } from "lucide-react";
 import { getProfilesByUserRole } from "@/db/repositories/profile";
 import {
   getActiveTournament,
   getTournamentBySlug,
 } from "@/db/repositories/tournament";
-import {
-  getGroupsWithParticipantsByTournamentId,
-  getGroupsByTournamentId,
-} from "@/db/repositories/group";
+import { getGroupsByTournamentId } from "@/db/repositories/group";
 import { Tournament } from "@/db/types/tournament";
 import { getTournamentWeeksByTournamentId } from "@/db/repositories/tournamentWeek";
 
@@ -46,9 +37,6 @@ export default async function Page({
 async function ManageTournament({ tournament }: { tournament?: Tournament }) {
   const adminProfiles = await getProfilesByUserRole("admin");
   const activeTournament = await getActiveTournament();
-  const groups = tournament
-    ? await getGroupsWithParticipantsByTournamentId(tournament.id)
-    : [];
   const groupNames = tournament
     ? await getGroupsByTournamentId(tournament.id)
     : [];
@@ -56,32 +44,15 @@ async function ManageTournament({ tournament }: { tournament?: Tournament }) {
     ? await getTournamentWeeksByTournamentId(tournament.id)
     : [];
 
-  const openCollapsible =
-    tournament == null ? "details" : groups.length > 0 ? "pairings" : "groups";
-
   return (
     <div className="space-y-4">
-      <Collapsible
-        defaultOpen={openCollapsible === "details"}
-        className="border border-primary rounded-md p-4"
-      >
-        <CollapsibleTrigger className="w-full">
-          <div className="flex">
-            <span className="flex-grow text-left">
-              Turnierdetails bearbeiten
-            </span>
-            <ChevronDownIcon />
-          </div>
-        </CollapsibleTrigger>
-        <CollapsibleContent className="mt-4">
-          <TournamentDetailsManager
-            adminProfiles={adminProfiles}
-            tournament={tournament}
-            tournamentWeeks={tournamentWeeks}
-            activeTournamentName={activeTournament?.name}
-          />
-        </CollapsibleContent>
-      </Collapsible>
+      <TournamentDetailsManager
+        adminProfiles={adminProfiles}
+        tournament={tournament}
+        tournamentWeeks={tournamentWeeks}
+        activeTournamentName={activeTournament?.name}
+        defaultOpen={tournament == null}
+      />
 
       <div className="border border-primary rounded-md p-4">
         <div className="flex items-center justify-between mb-4">

--- a/src/app/(main)/turniere/[slug]/kalender/page.tsx
+++ b/src/app/(main)/turniere/[slug]/kalender/page.tsx
@@ -11,6 +11,8 @@ import { getSetupHelperByUserId } from "@/db/repositories/setup-helper";
 import { getAllMatchdaysByTournamentId } from "@/db/repositories/match-day";
 import { getTournamentBySlug } from "@/db/repositories/tournament";
 import { getGroupAnnouncementDate } from "@/lib/tournament-schedule";
+import { tournamentPath } from "@/lib/navigation";
+import { redirect } from "next/navigation";
 
 export default async function Page({
   params,
@@ -31,6 +33,10 @@ export default async function Page({
     session ? getSetupHelperByUserId(session.user.id) : Promise.resolve(null),
     getTournamentBySlug(slug),
   ]);
+
+  if (activeTournament?.stage === "done") {
+    redirect(tournamentPath(slug, "/uebersicht"));
+  }
 
   const [participantEvents, refereeEvents, setupHelperEvents, matchdays] =
     await Promise.all([

--- a/src/app/(main)/turniere/[slug]/partieneingabe/page.tsx
+++ b/src/app/(main)/turniere/[slug]/partieneingabe/page.tsx
@@ -4,6 +4,7 @@ import { AssignedGroups } from "@/components/partieneingabe/assigned-groups";
 import { getGamesToEnterByUserId } from "@/db/repositories/game";
 import { getRolesByUserId } from "@/db/repositories/role";
 import { getMatchEnteringHelperIdByUserId } from "@/db/repositories/match-entering-helper";
+import { getTournamentBySlug } from "@/db/repositories/tournament";
 import { getUserGameRights } from "@/lib/game-auth";
 import { redirect } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
@@ -16,6 +17,11 @@ export default async function Page({
 }) {
   const session = await authWithRedirect();
   const { slug } = await params;
+
+  const tournament = await getTournamentBySlug(slug);
+  if (tournament?.stage === "done") {
+    redirect(tournamentPath(slug, "/uebersicht"));
+  }
 
   const userRoles = await getRolesByUserId(session.user.id);
   const canEnterAnyGame = userRoles.some((role) =>

--- a/src/app/(main)/turniere/[slug]/partienverlegung/page.tsx
+++ b/src/app/(main)/turniere/[slug]/partienverlegung/page.tsx
@@ -2,7 +2,8 @@ import { PostponementGrid } from "@/components/postponements/postponement-grid";
 import { authWithRedirect } from "@/auth/utils";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { buildGameViewUrl } from "@/lib/navigation";
+import { buildGameViewUrl, tournamentPath } from "@/lib/navigation";
+import { redirect } from "next/navigation";
 import { getAllPostponements } from "@/db/repositories/postponement";
 import { getTournamentBySlug } from "@/db/repositories/tournament";
 import { getParticipantWithGroupByProfileIdAndTournamentId } from "@/db/repositories/participant";
@@ -36,6 +37,10 @@ export default async function PostponementPage({
         </div>
       </div>
     );
+  }
+
+  if (tournament.stage === "done") {
+    redirect(tournamentPath(slug, "/uebersicht"));
   }
 
   if (tournament.stage !== "running") {

--- a/src/app/(main)/turniere/[slug]/rangliste/page.tsx
+++ b/src/app/(main)/turniere/[slug]/rangliste/page.tsx
@@ -3,7 +3,8 @@ import { getTournamentBySlug } from "@/db/repositories/tournament";
 import { getAllGroupNamesByTournamentId } from "@/db/repositories/game";
 import { StandingsDisplay } from "@/components/standings/standings-display";
 import { getGroupAnnouncementDate } from "@/lib/tournament-schedule";
-import { notFound } from "next/navigation";
+import { tournamentPath } from "@/lib/navigation";
+import { notFound, redirect } from "next/navigation";
 
 export default async function Page({
   params,
@@ -21,6 +22,10 @@ export default async function Page({
   const tournament = await getTournamentBySlug(slug);
   if (!tournament) {
     notFound();
+  }
+
+  if (tournament.stage === "done") {
+    redirect(tournamentPath(slug, "/uebersicht"));
   }
 
   const groups = await getAllGroupNamesByTournamentId(tournament.id);

--- a/src/app/(main)/turniere/[slug]/rangliste/page.tsx
+++ b/src/app/(main)/turniere/[slug]/rangliste/page.tsx
@@ -3,8 +3,7 @@ import { getTournamentBySlug } from "@/db/repositories/tournament";
 import { getAllGroupNamesByTournamentId } from "@/db/repositories/game";
 import { StandingsDisplay } from "@/components/standings/standings-display";
 import { getGroupAnnouncementDate } from "@/lib/tournament-schedule";
-import { tournamentPath } from "@/lib/navigation";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 
 export default async function Page({
   params,
@@ -22,10 +21,6 @@ export default async function Page({
   const tournament = await getTournamentBySlug(slug);
   if (!tournament) {
     notFound();
-  }
-
-  if (tournament.stage === "done") {
-    redirect(tournamentPath(slug, "/uebersicht"));
   }
 
   const groups = await getAllGroupNamesByTournamentId(tournament.id);

--- a/src/app/(main)/turniere/[slug]/uebersicht/page.tsx
+++ b/src/app/(main)/turniere/[slug]/uebersicht/page.tsx
@@ -10,10 +10,13 @@ import { notFound, redirect } from "next/navigation";
 
 export default async function Page({
   params,
+  searchParams,
 }: {
   params: Promise<{ slug: string }>;
+  searchParams: Promise<{ groupId?: string; round?: string }>;
 }) {
   const { slug } = await params;
+  const { groupId, round } = await searchParams;
   const tournament = await getTournamentBySlug(slug);
   const session = await auth();
 
@@ -37,6 +40,12 @@ export default async function Page({
   }
 
   if (tournament.stage === "done") {
-    return <TournamentDone />;
+    return (
+      <TournamentDone
+        tournament={tournament}
+        selectedGroupId={groupId}
+        selectedRound={round}
+      />
+    );
   }
 }

--- a/src/app/(main)/turniere/[slug]/uebersicht/page.tsx
+++ b/src/app/(main)/turniere/[slug]/uebersicht/page.tsx
@@ -10,13 +10,10 @@ import { notFound, redirect } from "next/navigation";
 
 export default async function Page({
   params,
-  searchParams,
 }: {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ groupId?: string; round?: string }>;
 }) {
   const { slug } = await params;
-  const { groupId, round } = await searchParams;
   const tournament = await getTournamentBySlug(slug);
   const session = await auth();
 
@@ -40,12 +37,6 @@ export default async function Page({
   }
 
   if (tournament.stage === "done") {
-    return (
-      <TournamentDone
-        tournament={tournament}
-        selectedGroupId={groupId}
-        selectedRound={round}
-      />
-    );
+    return <TournamentDone tournament={tournament} />;
   }
 }

--- a/src/app/(setup)/klubturnier-anmeldung/page.tsx
+++ b/src/app/(setup)/klubturnier-anmeldung/page.tsx
@@ -2,7 +2,12 @@ import { authWithRedirect } from "@/auth/utils";
 import { RolesManager } from "@/components/klubturnier-anmeldung/roles-manager";
 import { getProfileByUserId } from "@/db/repositories/profile";
 import { getRolesDataByProfileIdAndTournamentId } from "@/db/repositories/role";
-import { getOpenRegistrationTournament } from "@/db/repositories/tournament";
+import {
+  getMostRecentDoneTournament,
+  getOpenRegistrationTournament,
+} from "@/db/repositories/tournament";
+import { getParticipantByProfileIdAndTournamentId } from "@/db/repositories/participant";
+import { getPromotionEligibility } from "@/services/promotion";
 import { redirect } from "next/navigation";
 
 export default async function RolesPage() {
@@ -30,10 +35,19 @@ export default async function RolesPage() {
     );
   }
 
-  const initialValues = await getRolesDataByProfileIdAndTournamentId(
-    profile.id,
-    tournament.id,
-  );
+  const [initialValues, promotionEligibility] = await Promise.all([
+    getRolesDataByProfileIdAndTournamentId(profile.id, tournament.id),
+    getPromotionEligibility(profile.id),
+  ]);
+
+  const previousTournament = await getMostRecentDoneTournament();
+  const previousParticipant = previousTournament
+    ? await getParticipantByProfileIdAndTournamentId(
+        profile.id,
+        previousTournament.id,
+      )
+    : null;
+
   return (
     <div className="space-y-8">
       <header className="text-center">
@@ -51,6 +65,8 @@ export default async function RolesPage() {
         rolesData={initialValues}
         tournament={tournament}
         profile={profile}
+        promotionEligibility={promotionEligibility}
+        previousParticipant={previousParticipant ?? null}
       />
     </div>
   );

--- a/src/components/admin/groups/edit-groups-grid.tsx
+++ b/src/components/admin/groups/edit-groups-grid.tsx
@@ -13,6 +13,7 @@ import { NUMBER_OF_GROUPS_WITH_ELO } from "@/constants/constants";
 import invariant from "tiny-invariant";
 import { isError } from "@/lib/actions";
 import { sortParticipantsByElo, sortParticipantsByDwz } from "@/lib/elo";
+import { PromotionTargetsProvider } from "./promotion-targets-context";
 
 export function EditGroupsGrid({
   tournamentId,
@@ -20,12 +21,14 @@ export function EditGroupsGrid({
   unassignedParticipants: initialUnassignedParticipants,
   matchEnteringHelpers,
   currentAssignments,
+  promotionTargets,
 }: {
   tournamentId: number;
   groups: GridGroup[];
   unassignedParticipants: ParticipantWithName[];
   matchEnteringHelpers: MatchEnteringHelperWithName[];
   currentAssignments: Record<number, MatchEnteringHelperWithName[]>;
+  promotionTargets: Record<number, string>;
 }) {
   const [isPending, startTransition] = useTransition();
 
@@ -182,38 +185,40 @@ export function EditGroupsGrid({
   };
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex justify-end gap-4 items-center">
-        <Button
-          variant="outline"
-          onClick={handleAddNewGroup}
-          disabled={isPending}
-        >
-          Gruppe hinzufügen
-        </Button>
-        <Button onClick={handleSaveChanges} disabled={isPending}>
-          Änderungen speichern
-        </Button>
+    <PromotionTargetsProvider value={promotionTargets}>
+      <div className="flex flex-col gap-4">
+        <div className="flex justify-end gap-4 items-center">
+          <Button
+            variant="outline"
+            onClick={handleAddNewGroup}
+            disabled={isPending}
+          >
+            Gruppe hinzufügen
+          </Button>
+          <Button onClick={handleSaveChanges} disabled={isPending}>
+            Änderungen speichern
+          </Button>
+        </div>
+        <div className={isPending ? "opacity-50 pointer-events-none" : ""}>
+          <GroupsGrid
+            tournamentId={tournamentId}
+            groups={gridGroups}
+            unassignedParticipants={unassignedParticipants}
+            matchEnteringHelpers={matchEnteringHelpers}
+            helperAssignedCounts={helperAssignedCounts}
+            helperAssignments={helperAssignments}
+            onChangeGroups={setGridGroups}
+            onChangeUnassignedParticipants={setUnassignedParticipants}
+            onDeleteGroup={handleDeleteGroup}
+            onUpdateGroupName={handleUpdateGroupName}
+            onUpdateGroupTier={handleUpdateGroupTier}
+            onAddHelperToGroup={handleAddHelperToGroup}
+            onRemoveHelperFromGroup={handleRemoveHelperFromGroup}
+            onDistributeParticipants={handleDistributeParticipants}
+          />
+        </div>
       </div>
-      <div className={isPending ? "opacity-50 pointer-events-none" : ""}>
-        <GroupsGrid
-          tournamentId={tournamentId}
-          groups={gridGroups}
-          unassignedParticipants={unassignedParticipants}
-          matchEnteringHelpers={matchEnteringHelpers}
-          helperAssignedCounts={helperAssignedCounts}
-          helperAssignments={helperAssignments}
-          onChangeGroups={setGridGroups}
-          onChangeUnassignedParticipants={setUnassignedParticipants}
-          onDeleteGroup={handleDeleteGroup}
-          onUpdateGroupName={handleUpdateGroupName}
-          onUpdateGroupTier={handleUpdateGroupTier}
-          onAddHelperToGroup={handleAddHelperToGroup}
-          onRemoveHelperFromGroup={handleRemoveHelperFromGroup}
-          onDistributeParticipants={handleDistributeParticipants}
-        />
-      </div>
-    </div>
+    </PromotionTargetsProvider>
   );
 }
 

--- a/src/components/admin/groups/edit-groups-grid.tsx
+++ b/src/components/admin/groups/edit-groups-grid.tsx
@@ -174,6 +174,14 @@ export function EditGroupsGrid({
       return;
     }
 
+    const aGroupCount = gridGroups.filter(
+      (g) => !g.isDeleted && g.tier === 0,
+    ).length;
+    if (aGroupCount > 1) {
+      toast.error("Es darf nur eine Gruppe mit Stufe A geben.");
+      return;
+    }
+
     startTransition(async () => {
       const result = await saveGroups(tournamentId, gridGroups);
       if (isError(result)) {

--- a/src/components/admin/groups/edit-groups-grid.tsx
+++ b/src/components/admin/groups/edit-groups-grid.tsx
@@ -84,6 +84,7 @@ export function EditGroupsGrid({
       isDeleted: false,
       groupNumber: nextGroupNumber,
       groupName: generateGroupName(nextGroupNumber),
+      tier: null,
       dayOfWeek: null,
       participants: [],
       matchEnteringHelpers: [],
@@ -116,6 +117,13 @@ export function EditGroupsGrid({
   const handleUpdateGroupName = (groupId: number, newName: string) => {
     const updatedGroups = gridGroups.map((g) =>
       g.id === groupId ? { ...g, groupName: newName } : g,
+    );
+    setGridGroups(updatedGroups);
+  };
+
+  const handleUpdateGroupTier = (groupId: number, tier: number) => {
+    const updatedGroups = gridGroups.map((g) =>
+      g.id === groupId ? { ...g, tier } : g,
     );
     setGridGroups(updatedGroups);
   };
@@ -155,6 +163,14 @@ export function EditGroupsGrid({
   };
 
   const handleSaveChanges = () => {
+    const groupWithoutTier = gridGroups.find(
+      (g) => !g.isDeleted && g.tier == null,
+    );
+    if (groupWithoutTier) {
+      toast.error("Bitte für jede Gruppe eine Stufe angeben.");
+      return;
+    }
+
     startTransition(async () => {
       const result = await saveGroups(tournamentId, gridGroups);
       if (isError(result)) {
@@ -191,6 +207,7 @@ export function EditGroupsGrid({
           onChangeUnassignedParticipants={setUnassignedParticipants}
           onDeleteGroup={handleDeleteGroup}
           onUpdateGroupName={handleUpdateGroupName}
+          onUpdateGroupTier={handleUpdateGroupTier}
           onAddHelperToGroup={handleAddHelperToGroup}
           onRemoveHelperFromGroup={handleRemoveHelperFromGroup}
           onDistributeParticipants={handleDistributeParticipants}

--- a/src/components/admin/groups/edit-groups.tsx
+++ b/src/components/admin/groups/edit-groups.tsx
@@ -6,6 +6,7 @@ import { getUnassignedParticipantsByTournamentId } from "@/db/repositories/parti
 import { getAllMatchEnteringHelpersByTournamentId } from "@/db/repositories/admin";
 import { getGroupsWithMatchEnteringHelpersByTournamentId } from "@/db/repositories/group";
 import { MatchEnteringHelperWithName } from "@/db/types/match-entering-helper";
+import { getPromotionTargetsForPreviousEdition } from "@/services/promotion";
 
 export async function EditGroups({ tournament }: { tournament: Tournament }) {
   const groupsData = await getGroupsWithParticipantsByTournamentId(
@@ -54,6 +55,20 @@ export async function EditGroups({ tournament }: { tournament: Tournament }) {
       }) as GridGroup,
   );
 
+  const promotionTargets = await getPromotionTargetsForPreviousEdition();
+  const promotionByParticipantId: Record<number, string> = {};
+  for (const p of [
+    ...groups.flatMap((g) => g.participants),
+    ...unassignedParticipants,
+  ]) {
+    if (p.exercisePromotionRight === true) {
+      const target = promotionTargets.get(p.profileId);
+      if (target) {
+        promotionByParticipantId[p.id] = target.targetTierLetter;
+      }
+    }
+  }
+
   return (
     <EditGroupsGrid
       tournamentId={tournament.id}
@@ -61,6 +76,7 @@ export async function EditGroups({ tournament }: { tournament: Tournament }) {
       unassignedParticipants={unassignedParticipants}
       matchEnteringHelpers={matchEnteringHelpers}
       currentAssignments={currentAssignments}
+      promotionTargets={promotionByParticipantId}
     />
   );
 }

--- a/src/components/admin/groups/edit-groups.tsx
+++ b/src/components/admin/groups/edit-groups.tsx
@@ -44,6 +44,7 @@ export async function EditGroups({ tournament }: { tournament: Tournament }) {
         isDeleted: false,
         groupName: g.groupName,
         groupNumber: g.groupNumber,
+        tier: g.tier,
         dayOfWeek: g.dayOfWeek,
         participants: g.participants.map(({ groupPosition, participant }) => ({
           groupPosition: groupPosition,

--- a/src/components/admin/groups/group-tier.tsx
+++ b/src/components/admin/groups/group-tier.tsx
@@ -15,7 +15,7 @@ import {
 import { GridGroup } from "./types";
 import { tierLetter } from "@/lib/groups";
 
-const TIER_OPTIONS = [0, 1, 2, 3, 4];
+const TIER_OPTIONS = Array.from({ length: 26 }, (_, i) => i);
 
 type Props = {
   group: GridGroup;
@@ -42,7 +42,7 @@ export function GroupTier({ group, onChangeGroupTier }: Props) {
           <p>Spielstärke auswählen</p>
         </TooltipContent>
       </Tooltip>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" className="max-h-72 overflow-y-auto">
         {TIER_OPTIONS.map((tier) => (
           <DropdownMenuItem
             key={tier}

--- a/src/components/admin/groups/group-tier.tsx
+++ b/src/components/admin/groups/group-tier.tsx
@@ -7,6 +7,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { GridGroup } from "./types";
 import { tierLetter } from "@/lib/groups";
 
@@ -20,16 +25,23 @@ type Props = {
 export function GroupTier({ group, onChangeGroupTier }: Props) {
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          size="icon"
-          variant="outline"
-          className="font-semibold"
-          aria-label="Stufe wählen"
-        >
-          {group.tier != null ? tierLetter(group.tier) : "?"}
-        </Button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="icon"
+              variant="outline"
+              className="font-semibold"
+              aria-label="Spielstärke auswählen"
+            >
+              {group.tier != null ? tierLetter(group.tier) : "?"}
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Spielstärke auswählen</p>
+        </TooltipContent>
+      </Tooltip>
       <DropdownMenuContent align="end">
         {TIER_OPTIONS.map((tier) => (
           <DropdownMenuItem

--- a/src/components/admin/groups/group-tier.tsx
+++ b/src/components/admin/groups/group-tier.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { GridGroup } from "./types";
+import { tierLetter } from "@/lib/groups";
+
+const TIER_OPTIONS = [0, 1, 2, 3, 4];
+
+type Props = {
+  group: GridGroup;
+  onChangeGroupTier: (groupId: number, tier: number) => void;
+};
+
+export function GroupTier({ group, onChangeGroupTier }: Props) {
+  const handleTierChange = (value: string) => {
+    onChangeGroupTier(group.id, Number(value));
+  };
+
+  return (
+    <Select
+      value={group.tier != null ? group.tier.toString() : undefined}
+      onValueChange={handleTierChange}
+    >
+      <SelectTrigger className="w-full">
+        <SelectValue placeholder="Stufe" />
+      </SelectTrigger>
+      <SelectContent>
+        {TIER_OPTIONS.map((tier) => (
+          <SelectItem key={tier} value={tier.toString()}>
+            Stufe {tierLetter(tier)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/admin/groups/group-tier.tsx
+++ b/src/components/admin/groups/group-tier.tsx
@@ -7,11 +7,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { GridGroup } from "./types";
 import { tierLetter } from "@/lib/groups";
 
@@ -25,23 +20,16 @@ type Props = {
 export function GroupTier({ group, onChangeGroupTier }: Props) {
   return (
     <DropdownMenu>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button
-              size="icon"
-              variant="outline"
-              className="font-semibold"
-              aria-label="Spielstärke auswählen"
-            >
-              {group.tier != null ? tierLetter(group.tier) : "?"}
-            </Button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>Spielstärke auswählen</p>
-        </TooltipContent>
-      </Tooltip>
+      <DropdownMenuTrigger asChild>
+        <Button
+          size="icon"
+          variant="outline"
+          className="font-semibold"
+          aria-label="Spielstärke auswählen"
+        >
+          {group.tier != null ? tierLetter(group.tier) : "?"}
+        </Button>
+      </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="max-h-72 overflow-y-auto">
         {TIER_OPTIONS.map((tier) => (
           <DropdownMenuItem

--- a/src/components/admin/groups/group-tier.tsx
+++ b/src/components/admin/groups/group-tier.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { GridGroup } from "./types";
 import { tierLetter } from "@/lib/groups";
 
@@ -18,25 +18,28 @@ type Props = {
 };
 
 export function GroupTier({ group, onChangeGroupTier }: Props) {
-  const handleTierChange = (value: string) => {
-    onChangeGroupTier(group.id, Number(value));
-  };
-
   return (
-    <Select
-      value={group.tier != null ? group.tier.toString() : undefined}
-      onValueChange={handleTierChange}
-    >
-      <SelectTrigger className="w-full">
-        <SelectValue placeholder="Stufe" />
-      </SelectTrigger>
-      <SelectContent>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          size="icon"
+          variant="outline"
+          className="font-semibold"
+          aria-label="Stufe wählen"
+        >
+          {group.tier != null ? tierLetter(group.tier) : "?"}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
         {TIER_OPTIONS.map((tier) => (
-          <SelectItem key={tier} value={tier.toString()}>
+          <DropdownMenuItem
+            key={tier}
+            onClick={() => onChangeGroupTier(group.id, tier)}
+          >
             Stufe {tierLetter(tier)}
-          </SelectItem>
+          </DropdownMenuItem>
         ))}
-      </SelectContent>
-    </Select>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/src/components/admin/groups/group-title.tsx
+++ b/src/components/admin/groups/group-title.tsx
@@ -3,18 +3,20 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Pen } from "lucide-react";
-import { ChangeEventHandler, useState } from "react";
+import { ChangeEventHandler, ReactNode, useState } from "react";
 
 type Props = {
   groupId: number;
   groupName: string;
   onChangeGroupName: (groupId: number, groupName: string) => void;
+  tierControl?: ReactNode;
 };
 
 export function GroupTitle({
   groupId,
   groupName: initialGroupName,
   onChangeGroupName,
+  tierControl,
 }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [groupName, setGroupName] = useState(initialGroupName);
@@ -61,6 +63,7 @@ export function GroupTitle({
       ) : (
         <span className="flex-1">{groupName}</span>
       )}
+      {tierControl}
       <Button size="icon" variant="ghost" onClick={handleEditClick}>
         <Pen className="h-4 w-4" />
       </Button>

--- a/src/components/admin/groups/group-title.tsx
+++ b/src/components/admin/groups/group-title.tsx
@@ -63,10 +63,10 @@ export function GroupTitle({
       ) : (
         <span className="flex-1">{groupName}</span>
       )}
-      {tierControl}
       <Button size="icon" variant="ghost" onClick={handleEditClick}>
         <Pen className="h-4 w-4" />
       </Button>
+      {tierControl}
     </div>
   );
 }

--- a/src/components/admin/groups/groups-grid.tsx
+++ b/src/components/admin/groups/groups-grid.tsx
@@ -19,6 +19,7 @@ import invariant from "tiny-invariant";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { GridGroup } from "./types";
 import { GroupMatchDay } from "./group-match-day";
+import { GroupTier } from "./group-tier";
 import { ParticipantEntry } from "./participant-entry";
 import { GroupTitle } from "./group-title";
 import { GroupStats } from "./group-stats";
@@ -50,6 +51,7 @@ export function GroupsGrid({
   onChangeUnassignedParticipants,
   onDeleteGroup,
   onUpdateGroupName,
+  onUpdateGroupTier,
   onAddHelperToGroup,
   onRemoveHelperFromGroup,
   onDistributeParticipants,
@@ -64,6 +66,7 @@ export function GroupsGrid({
   onChangeUnassignedParticipants: (participants: ParticipantWithName[]) => void;
   onDeleteGroup: (groupId: number) => void;
   onUpdateGroupName: (groupId: number, newName: string) => void;
+  onUpdateGroupTier: (groupId: number, tier: number) => void;
   onAddHelperToGroup: (groupId: number, helperId: number) => void;
   onRemoveHelperFromGroup: (groupId: number, helperId: number) => void;
   onDistributeParticipants: (participantsPerGroup: number) => void;
@@ -92,6 +95,10 @@ export function GroupsGrid({
 
   const handleChangeGroupName = (groupId: number, newName: string) => {
     onUpdateGroupName(groupId, newName);
+  };
+
+  const handleChangeGroupTier = (groupId: number, tier: number) => {
+    onUpdateGroupTier(groupId, tier);
   };
 
   const handleChangeGroupMatchDay = (
@@ -222,6 +229,7 @@ export function GroupsGrid({
                   key={`${group.id}+${group.participants.length}`}
                   group={group}
                   onChangeGroupName={handleChangeGroupName}
+                  onChangeGroupTier={handleChangeGroupTier}
                   onChangeGroupMatchDay={handleChangeGroupMatchDay}
                   onDeleteGroup={onDeleteGroup}
                   matchEnteringHelpers={matchEnteringHelpers}
@@ -249,6 +257,7 @@ export function GroupsGrid({
 export function GroupContainer({
   group,
   onChangeGroupName,
+  onChangeGroupTier,
   onChangeGroupMatchDay,
   onDeleteGroup,
   matchEnteringHelpers,
@@ -261,6 +270,7 @@ export function GroupContainer({
   matchEnteringHelpers: MatchEnteringHelperWithName[];
   helperAssignedCounts: Record<number, number>;
   onChangeGroupName: (groupId: number, newName: string) => void;
+  onChangeGroupTier: (groupId: number, tier: number) => void;
   onChangeGroupMatchDay: (groupId: number, matchDay: DayOfWeek | null) => void;
   onDeleteGroup: (groupId: number) => void;
   onAddHelperToGroup: (groupId: number, helperId: number) => void;
@@ -312,6 +322,10 @@ export function GroupContainer({
         className="p-0 pl-4 pb-4 pr-4 md:p-0 md:pl-6 md:pb-6 md:pr-6 flex flex-col h-full"
       >
         <div className="space-y-4 flex-1 flex flex-col">
+          <div className="px-2">
+            <GroupTier group={group} onChangeGroupTier={onChangeGroupTier} />
+          </div>
+
           <div className="px-2">
             <GroupMatchDay
               group={group}

--- a/src/components/admin/groups/groups-grid.tsx
+++ b/src/components/admin/groups/groups-grid.tsx
@@ -36,6 +36,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { sortParticipantsByDwz } from "@/lib/elo";
+import { usePromotionTarget } from "./promotion-targets-context";
 
 export const UNASSIGNED_CONTAINER_ID = "unassigned-droppable";
 const UNASSIGNED_CONTAINER_TYPE = "unassigned";
@@ -451,6 +452,8 @@ export function ParticipantItem({
       },
     });
 
+  const promotionTarget = usePromotionTarget(participant.id);
+
   const style = {
     transform: CSS.Translate.toString(transform),
   };
@@ -465,7 +468,10 @@ export function ParticipantItem({
       {...listeners}
       className={`px-2 py-1 rounded-md shadow-sm cursor-grab active:cursor-grabbing ${draggingClasses}`}
     >
-      <ParticipantEntry participant={participant} />
+      <ParticipantEntry
+        participant={participant}
+        promotionTarget={promotionTarget}
+      />
     </div>
   );
 }

--- a/src/components/admin/groups/groups-grid.tsx
+++ b/src/components/admin/groups/groups-grid.tsx
@@ -299,12 +299,18 @@ export function GroupContainer({
     >
       <CardHeader>
         <CardTitle>
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
             <div className="flex-1">
               <GroupTitle
                 onChangeGroupName={onChangeGroupName}
                 groupId={group.id}
                 groupName={group.groupName}
+                tierControl={
+                  <GroupTier
+                    group={group}
+                    onChangeGroupTier={onChangeGroupTier}
+                  />
+                }
               />
             </div>
             <Button
@@ -323,10 +329,6 @@ export function GroupContainer({
         className="p-0 pl-4 pb-4 pr-4 md:p-0 md:pl-6 md:pb-6 md:pr-6 flex flex-col h-full"
       >
         <div className="space-y-4 flex-1 flex flex-col">
-          <div className="px-2">
-            <GroupTier group={group} onChangeGroupTier={onChangeGroupTier} />
-          </div>
-
           <div className="px-2">
             <GroupMatchDay
               group={group}

--- a/src/components/admin/groups/participant-entry.tsx
+++ b/src/components/admin/groups/participant-entry.tsx
@@ -1,20 +1,38 @@
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { ParticipantWithName } from "@/db/types/participant";
+import { Crown } from "lucide-react";
 import { UserWeekdayDisplay } from "../user-weekday-display";
 
 export function ParticipantEntry({
   participant,
+  promotionTarget,
   showMatchDays = true,
   showFideRating = true,
   showDwzRating = true,
 }: {
   participant: ParticipantWithName;
+  promotionTarget?: string;
   showMatchDays?: boolean;
   showFideRating?: boolean;
   showDwzRating?: boolean;
 }) {
   return (
     <div className="flex items-center gap-2 py-1">
+      {promotionTarget ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Crown className="h-4 w-4 shrink-0 text-amber-500" />
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Aufstiegsrecht in Gruppe {promotionTarget}</p>
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
       <p className="font-semibold flex-grow truncate">
         {participant.profile.firstName} {participant.profile.lastName}
       </p>

--- a/src/components/admin/groups/promotion-targets-context.tsx
+++ b/src/components/admin/groups/promotion-targets-context.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+const PromotionTargetsContext = createContext<Record<number, string>>({});
+
+export const PromotionTargetsProvider = PromotionTargetsContext.Provider;
+
+export function usePromotionTarget(participantId: number): string | undefined {
+  return useContext(PromotionTargetsContext)[participantId];
+}

--- a/src/components/admin/groups/types.ts
+++ b/src/components/admin/groups/types.ts
@@ -8,6 +8,7 @@ export type GridGroup = {
   isDeleted: boolean;
   groupNumber: number;
   groupName: string;
+  tier: number | null;
   dayOfWeek: DayOfWeek | null;
   participants: ParticipantWithName[];
   matchEnteringHelpers: MatchEnteringHelperWithName[];

--- a/src/components/admin/tournament/tournament-details-manager.tsx
+++ b/src/components/admin/tournament/tournament-details-manager.tsx
@@ -4,7 +4,12 @@ import { useState } from "react";
 import EditTournamentDetails from "./edit-tournament-details";
 import CreateTournament from "./create-tournament";
 import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ChevronDownIcon, Plus } from "lucide-react";
 import { Profile } from "@/db/types/profile";
 import { Tournament } from "@/db/types/tournament";
 import { TournamentWeekWithMatchdays } from "@/db/types/tournamentWeek";
@@ -15,6 +20,7 @@ type Props = {
   tournament?: Tournament;
   tournamentWeeks: TournamentWeekWithMatchdays[];
   activeTournamentName?: string;
+  defaultOpen: boolean;
 };
 
 export default function TournamentDetailsManager({
@@ -22,53 +28,62 @@ export default function TournamentDetailsManager({
   tournament,
   tournamentWeeks,
   activeTournamentName,
+  defaultOpen,
 }: Props) {
+  const [open, setOpen] = useState(defaultOpen);
   const [showCreateForm, setShowCreateForm] = useState(false);
 
-  if (showCreateForm) {
-    return (
-      <CreateTournament
-        profiles={adminProfiles}
-        onCancel={() => setShowCreateForm(false)}
-      />
-    );
-  }
+  const handleCreateClick = () => {
+    if (activeTournamentName) {
+      toast.error(`${activeTournamentName} ist noch nicht abgeschlossen.`);
+      return;
+    }
+    setOpen(true);
+    setShowCreateForm(true);
+  };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-medium">
-          {tournament ? "Turnier bearbeiten" : "Kein Turnier gefunden"}
-        </h3>
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="border border-primary rounded-md p-4"
+    >
+      <div className="flex items-center gap-2">
+        <CollapsibleTrigger className="flex-grow text-left font-medium">
+          Turnierdetails bearbeiten
+        </CollapsibleTrigger>
         <Button
-          onClick={() => {
-            if (activeTournamentName) {
-              toast.error(`${activeTournamentName} ist noch nicht abgeschlossen.`);
-              return;
-            }
-            setShowCreateForm(true);
-          }}
+          onClick={handleCreateClick}
           size="sm"
-          className="flex items-center gap-2"
+          className="flex shrink-0 items-center gap-2"
         >
           <Plus className="h-4 w-4" />
           Neues Turnier erstellen
         </Button>
+        <CollapsibleTrigger className="shrink-0">
+          <ChevronDownIcon className="h-5 w-5" />
+        </CollapsibleTrigger>
       </div>
-
-      {tournament ? (
-        <EditTournamentDetails
-          profiles={adminProfiles}
-          tournament={tournament}
-          tournamentWeeks={tournamentWeeks}
-        />
-      ) : (
-        <div className="text-center py-8 text-muted-foreground">
-          <p>
-            Kein Turnier gefunden. Erstelle ein neues Turnier, um zu beginnen.
-          </p>
-        </div>
-      )}
-    </div>
+      <CollapsibleContent className="mt-4">
+        {showCreateForm ? (
+          <CreateTournament
+            profiles={adminProfiles}
+            onCancel={() => setShowCreateForm(false)}
+          />
+        ) : tournament ? (
+          <EditTournamentDetails
+            profiles={adminProfiles}
+            tournament={tournament}
+            tournamentWeeks={tournamentWeeks}
+          />
+        ) : (
+          <div className="text-center py-8 text-muted-foreground">
+            <p>
+              Kein Turnier gefunden. Erstelle ein neues Turnier, um zu beginnen.
+            </p>
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
   );
 }

--- a/src/components/admin/tournament/tournament-details-manager.tsx
+++ b/src/components/admin/tournament/tournament-details-manager.tsx
@@ -8,17 +8,20 @@ import { Plus } from "lucide-react";
 import { Profile } from "@/db/types/profile";
 import { Tournament } from "@/db/types/tournament";
 import { TournamentWeekWithMatchdays } from "@/db/types/tournamentWeek";
+import { toast } from "sonner";
 
 type Props = {
   adminProfiles: Profile[];
   tournament?: Tournament;
   tournamentWeeks: TournamentWeekWithMatchdays[];
+  activeTournamentName?: string;
 };
 
 export default function TournamentDetailsManager({
   adminProfiles,
   tournament,
   tournamentWeeks,
+  activeTournamentName,
 }: Props) {
   const [showCreateForm, setShowCreateForm] = useState(false);
 
@@ -38,7 +41,15 @@ export default function TournamentDetailsManager({
           {tournament ? "Turnier bearbeiten" : "Kein Turnier gefunden"}
         </h3>
         <Button
-          onClick={() => setShowCreateForm(true)}
+          onClick={() => {
+            if (activeTournamentName) {
+              toast.error(
+                `„${activeTournamentName}" ist noch nicht abgeschlossen. Alle bestehenden Turniere müssen abgeschlossen sein, bevor du ein neues anlegst.`,
+              );
+              return;
+            }
+            setShowCreateForm(true);
+          }}
           size="sm"
           className="flex items-center gap-2"
         >

--- a/src/components/admin/tournament/tournament-details-manager.tsx
+++ b/src/components/admin/tournament/tournament-details-manager.tsx
@@ -43,9 +43,7 @@ export default function TournamentDetailsManager({
         <Button
           onClick={() => {
             if (activeTournamentName) {
-              toast.error(
-                `„${activeTournamentName}" ist noch nicht abgeschlossen. Alle bestehenden Turniere müssen abgeschlossen sein, bevor du ein neues anlegst.`,
-              );
+              toast.error(`${activeTournamentName} ist noch nicht abgeschlossen.`);
               return;
             }
             setShowCreateForm(true);

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -35,9 +35,13 @@ import { Tournament } from "@/db/types/tournament";
 import { getParticipantEloData } from "@/actions/participant";
 import { Profile } from "@/db/types/profile";
 import { DEFAULT_CLUB_KEY, DEFAULT_CLUB_LABEL } from "@/constants/constants";
+import { Switch } from "@/components/ui/switch";
+import type { PromotionEligibility } from "@/services/promotion";
 
 type Props = {
   initialValues?: z.infer<typeof participantFormSchema>;
+  canDelete: boolean;
+  promotionEligibility: PromotionEligibility | null;
   onSubmit: (data: z.infer<typeof participantFormSchema>) => Promise<void>;
   onDelete: () => Promise<void>;
   tournament: Tournament;
@@ -46,6 +50,8 @@ type Props = {
 
 export function ParticipateForm({
   initialValues,
+  canDelete,
+  promotionEligibility,
   onSubmit,
   onDelete,
   tournament,
@@ -68,6 +74,7 @@ export function ParticipateForm({
       preferredMatchDay: initialValues?.preferredMatchDay,
       secondaryMatchDays: initialValues?.secondaryMatchDays ?? [],
       notAvailableDays: initialValues?.notAvailableDays ?? [],
+      exercisePromotionRight: initialValues?.exercisePromotionRight ?? false,
     },
   });
 
@@ -463,6 +470,41 @@ export function ParticipateForm({
           )}
         />
 
+        {promotionEligibility != null ? (
+          <FormField
+            control={form.control}
+            name="exercisePromotionRight"
+            render={({ field }) => (
+              <FormItem className="space-y-3 rounded-md border p-4">
+                <div className="flex flex-row items-center justify-between gap-3 space-y-0">
+                  <div className="space-y-1">
+                    <FormLabel>
+                      Möchtest du dein Aufstiegsrecht wahrnehmen?
+                    </FormLabel>
+                    <FormDescription>
+                      Als Sieger der Gruppe {promotionEligibility.wonGroupName}{" "}
+                      hast du das Recht, in die Gruppe{" "}
+                      {promotionEligibility.targetTierLetter} aufzusteigen.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value ?? false}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </div>
+                {promotionEligibility.targetIsAGroup ? (
+                  <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
+                    Beachte: Die A-Gruppe spielt nur freitags.
+                  </p>
+                ) : null}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        ) : null}
+
         <div className="flex items-center gap-2">
           <Button
             disabled={isPending}
@@ -471,8 +513,7 @@ export function ParticipateForm({
           >
             Änderungen speichern
           </Button>
-          {initialValues !== undefined &&
-          tournament.stage === "registration" ? (
+          {canDelete && tournament.stage === "registration" ? (
             <Button
               disabled={isPending}
               className="w-full sm:w-auto "

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -147,6 +147,41 @@ export function ParticipateForm({
         onSubmit={form.handleSubmit(handleSubmit)}
         className="space-y-6 pt-4"
       >
+        {promotionEligibility != null ? (
+          <FormField
+            control={form.control}
+            name="exercisePromotionRight"
+            render={({ field }) => (
+              <FormItem className="space-y-3 rounded-md border border-amber-200 bg-amber-50/60 p-4 dark:border-amber-900/40 dark:bg-amber-950/20">
+                <div className="flex flex-row items-center justify-between gap-3 space-y-0">
+                  <div className="space-y-1">
+                    <FormLabel>
+                      Möchtest du dein Aufstiegsrecht wahrnehmen?
+                    </FormLabel>
+                    <FormDescription>
+                      Als Sieger der Gruppe {promotionEligibility.wonGroupName}{" "}
+                      hast du das Recht, in die Gruppe{" "}
+                      {promotionEligibility.targetTierLetter} aufzusteigen.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value ?? false}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </div>
+                {promotionEligibility.targetIsAGroup ? (
+                  <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
+                    Beachte: Die A-Gruppe spielt nur freitags.
+                  </p>
+                ) : null}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        ) : null}
+
         <div className="flex gap-4">
           <FormField
             control={form.control}
@@ -469,41 +504,6 @@ export function ParticipateForm({
             </FormItem>
           )}
         />
-
-        {promotionEligibility != null ? (
-          <FormField
-            control={form.control}
-            name="exercisePromotionRight"
-            render={({ field }) => (
-              <FormItem className="space-y-3 rounded-md border p-4">
-                <div className="flex flex-row items-center justify-between gap-3 space-y-0">
-                  <div className="space-y-1">
-                    <FormLabel>
-                      Möchtest du dein Aufstiegsrecht wahrnehmen?
-                    </FormLabel>
-                    <FormDescription>
-                      Als Sieger der Gruppe {promotionEligibility.wonGroupName}{" "}
-                      hast du das Recht, in die Gruppe{" "}
-                      {promotionEligibility.targetTierLetter} aufzusteigen.
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value ?? false}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </div>
-                {promotionEligibility.targetIsAGroup ? (
-                  <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
-                    Beachte: Die A-Gruppe spielt nur freitags.
-                  </p>
-                ) : null}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        ) : null}
 
         <div className="flex items-center gap-2">
           <Button

--- a/src/components/klubturnier-anmeldung/roles-manager.tsx
+++ b/src/components/klubturnier-anmeldung/roles-manager.tsx
@@ -29,12 +29,16 @@ import { sendRolesSelectionSummaryEmail } from "@/actions/email/roles";
 import { Profile } from "@/db/types/profile";
 import { DEFAULT_CLUB_KEY, DEFAULT_CLUB_LABEL } from "@/constants/constants";
 import { createReferee, deleteReferee } from "@/actions/referee";
+import { Participant } from "@/db/types/participant";
+import type { PromotionEligibility } from "@/services/promotion";
 
 type Props = {
   userId: string;
   rolesData: RolesData;
   tournament: Tournament;
   profile: Profile;
+  promotionEligibility: PromotionEligibility | null;
+  previousParticipant: Participant | null;
 };
 
 export function RolesManager({
@@ -42,7 +46,14 @@ export function RolesManager({
   rolesData,
   tournament,
   profile,
+  promotionEligibility,
+  previousParticipant,
 }: Props) {
+  const participantInitialValues = buildParticipantInitialValues(
+    rolesData.participant,
+    previousParticipant,
+  );
+  const canDeleteParticipant = rolesData.participant != null;
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
   const [accordionValue, setAccordionValue] = useState<string>();
@@ -145,28 +156,9 @@ export function RolesManager({
           icon={User}
         >
           <ParticipateForm
-            initialValues={
-              rolesData.participant
-                ? {
-                    chessClubType:
-                      rolesData.participant.chessClub === DEFAULT_CLUB_LABEL
-                        ? DEFAULT_CLUB_KEY
-                        : "other",
-                    chessClub: rolesData.participant.chessClub,
-                    preferredMatchDay: rolesData.participant.preferredMatchDay,
-                    secondaryMatchDays:
-                      rolesData.participant.secondaryMatchDays,
-                    title: rolesData.participant.title ?? "noTitle",
-                    nationality: rolesData.participant.nationality ?? undefined,
-                    dwzRating: rolesData.participant.dwzRating ?? undefined,
-                    fideRating: rolesData.participant.fideRating ?? undefined,
-                    fideId: rolesData.participant.fideId ?? undefined,
-                    birthYear: rolesData.participant.birthYear ?? undefined,
-                    notAvailableDays:
-                      rolesData.participant.notAvailableDays ?? [],
-                  }
-                : undefined
-            }
+            initialValues={participantInitialValues}
+            canDelete={canDeleteParticipant}
+            promotionEligibility={promotionEligibility}
             onSubmit={handleParticipateFormSubmit}
             onDelete={handleDeleteParticipant}
             tournament={tournament}
@@ -253,4 +245,47 @@ export function RolesManager({
       ) : null}
     </div>
   );
+}
+
+function buildParticipantInitialValues(
+  current: RolesData["participant"],
+  previous: Participant | null,
+): z.infer<typeof participantFormSchema> | undefined {
+  if (current) {
+    return {
+      chessClubType:
+        current.chessClub === DEFAULT_CLUB_LABEL ? DEFAULT_CLUB_KEY : "other",
+      chessClub: current.chessClub,
+      title: current.title ?? "noTitle",
+      nationality: current.nationality ?? undefined,
+      dwzRating: current.dwzRating ?? undefined,
+      fideRating: current.fideRating ?? undefined,
+      fideId: current.fideId ?? undefined,
+      birthYear: current.birthYear ?? undefined,
+      preferredMatchDay: current.preferredMatchDay,
+      secondaryMatchDays: current.secondaryMatchDays,
+      notAvailableDays: current.notAvailableDays ?? [],
+      exercisePromotionRight: current.exercisePromotionRight ?? false,
+    };
+  }
+
+  if (previous) {
+    return {
+      chessClubType:
+        previous.chessClub === DEFAULT_CLUB_LABEL ? DEFAULT_CLUB_KEY : "other",
+      chessClub: previous.chessClub,
+      title: previous.title ?? "noTitle",
+      nationality: previous.nationality ?? undefined,
+      fideId: previous.fideId ?? undefined,
+      birthYear: previous.birthYear ?? undefined,
+      preferredMatchDay: previous.preferredMatchDay,
+      secondaryMatchDays: previous.secondaryMatchDays,
+      zpsClub: previous.zpsClubId ?? undefined,
+      zpsPlayer: previous.zpsPlayerId ?? undefined,
+      notAvailableDays: [],
+      exercisePromotionRight: false,
+    };
+  }
+
+  return undefined;
 }

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -68,7 +68,7 @@ export function AppSidebar({ session, tournaments, userRoles }: Props) {
   const isRegistrationOpen = stage === "registration";
   const isRunning = stage === "running";
   const isActive = stage === "registration" || stage === "running";
-  const isArchived = stage === "done";
+  const isDone = stage === "done";
 
   const isAdmin = userRoles.includes("admin");
   const isParticipant = userRoles.includes("participant");
@@ -117,15 +117,13 @@ export function AppSidebar({ session, tournaments, userRoles }: Props) {
               >
                 Partien
               </SidebarLink>
-              {!isArchived && (
-                <SidebarLink
-                  href={tournamentPath(slug, "/rangliste")}
-                  icon={Medal}
-                >
-                  Rangliste
-                </SidebarLink>
-              )}
-              {!isArchived && (
+              <SidebarLink
+                href={tournamentPath(slug, "/rangliste")}
+                icon={Medal}
+              >
+                Rangliste
+              </SidebarLink>
+              {!isDone && (
                 <SidebarLink
                   href={tournamentPath(slug, "/kalender")}
                   icon={CalendarIcon}

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -68,6 +68,7 @@ export function AppSidebar({ session, tournaments, userRoles }: Props) {
   const isRegistrationOpen = stage === "registration";
   const isRunning = stage === "running";
   const isActive = stage === "registration" || stage === "running";
+  const isArchived = stage === "done";
 
   const isAdmin = userRoles.includes("admin");
   const isParticipant = userRoles.includes("participant");
@@ -116,18 +117,22 @@ export function AppSidebar({ session, tournaments, userRoles }: Props) {
               >
                 Partien
               </SidebarLink>
-              <SidebarLink
-                href={tournamentPath(slug, "/rangliste")}
-                icon={Medal}
-              >
-                Rangliste
-              </SidebarLink>
-              <SidebarLink
-                href={tournamentPath(slug, "/kalender")}
-                icon={CalendarIcon}
-              >
-                Kalender
-              </SidebarLink>
+              {!isArchived && (
+                <SidebarLink
+                  href={tournamentPath(slug, "/rangliste")}
+                  icon={Medal}
+                >
+                  Rangliste
+                </SidebarLink>
+              )}
+              {!isArchived && (
+                <SidebarLink
+                  href={tournamentPath(slug, "/kalender")}
+                  icon={CalendarIcon}
+                >
+                  Kalender
+                </SidebarLink>
+              )}
               {isRunning && (isSetupHelper || isReferee) && (
                 <SidebarLink
                   href={tournamentPath(slug, "/terminuebersicht")}

--- a/src/components/standings/standings-display.tsx
+++ b/src/components/standings/standings-display.tsx
@@ -9,7 +9,6 @@ type Props = {
   rounds: number[];
   selectedGroupId: string;
   selectedRound?: string;
-  basePath?: string;
 };
 
 export async function StandingsDisplay({
@@ -17,7 +16,6 @@ export async function StandingsDisplay({
   rounds,
   selectedGroupId,
   selectedRound,
-  basePath,
 }: Props) {
   const parsedGroupId = Number(selectedGroupId);
   const groupId = Number.isNaN(parsedGroupId) ? groups[0].id : parsedGroupId;
@@ -35,7 +33,6 @@ export async function StandingsDisplay({
         rounds={rounds}
         selectedGroupId={selectedGroupId}
         selectedRound={selectedRound}
-        basePath={basePath}
       />
 
       <StandingsTable

--- a/src/components/standings/standings-display.tsx
+++ b/src/components/standings/standings-display.tsx
@@ -9,6 +9,7 @@ type Props = {
   rounds: number[];
   selectedGroupId: string;
   selectedRound?: string;
+  basePath?: string;
 };
 
 export async function StandingsDisplay({
@@ -16,8 +17,10 @@ export async function StandingsDisplay({
   rounds,
   selectedGroupId,
   selectedRound,
+  basePath,
 }: Props) {
-  const groupId = Number(selectedGroupId);
+  const parsedGroupId = Number(selectedGroupId);
+  const groupId = Number.isNaN(parsedGroupId) ? groups[0].id : parsedGroupId;
   const round = selectedRound != null ? Number(selectedRound) : undefined;
 
   const participants = await getParticipantsInGroup(groupId);
@@ -32,6 +35,7 @@ export async function StandingsDisplay({
         rounds={rounds}
         selectedGroupId={selectedGroupId}
         selectedRound={selectedRound}
+        basePath={basePath}
       />
 
       <StandingsTable

--- a/src/components/standings/standings-selector.tsx
+++ b/src/components/standings/standings-selector.tsx
@@ -18,7 +18,6 @@ export type Props = {
   groups: GroupSummary[];
   selectedRound?: string;
   rounds: number[];
-  basePath?: string;
 };
 
 export function StandingsSelector({
@@ -26,7 +25,6 @@ export function StandingsSelector({
   rounds,
   selectedGroupId,
   selectedRound,
-  basePath,
 }: Props) {
   const router = useRouter();
   const slug = useTournamentSlug();
@@ -37,7 +35,6 @@ export function StandingsSelector({
         slug,
         groupId,
         round: selectedRound,
-        basePath,
       }),
     );
   };
@@ -48,7 +45,6 @@ export function StandingsSelector({
         slug,
         groupId: selectedGroupId,
         round,
-        basePath,
       }),
     );
   };

--- a/src/components/standings/standings-selector.tsx
+++ b/src/components/standings/standings-selector.tsx
@@ -18,6 +18,7 @@ export type Props = {
   groups: GroupSummary[];
   selectedRound?: string;
   rounds: number[];
+  basePath?: string;
 };
 
 export function StandingsSelector({
@@ -25,6 +26,7 @@ export function StandingsSelector({
   rounds,
   selectedGroupId,
   selectedRound,
+  basePath,
 }: Props) {
   const router = useRouter();
   const slug = useTournamentSlug();
@@ -35,6 +37,7 @@ export function StandingsSelector({
         slug,
         groupId,
         round: selectedRound,
+        basePath,
       }),
     );
   };
@@ -45,6 +48,7 @@ export function StandingsSelector({
         slug,
         groupId: selectedGroupId,
         round,
+        basePath,
       }),
     );
   };

--- a/src/components/uebersicht/tournament-done.tsx
+++ b/src/components/uebersicht/tournament-done.tsx
@@ -3,13 +3,7 @@ import {
   getParticipantsInGroup,
 } from "@/db/repositories/game";
 import { getStandings } from "@/services/standings";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { Tournament } from "@/db/types/tournament";
 import { auth } from "@/auth/utils";
 import { getProfileByUserId } from "@/db/repositories/profile";
@@ -43,14 +37,17 @@ export async function TournamentDone({
         </p>
       </div>
       {champion != null ? (
-        <Card>
-          <CardHeader>
-            <CardTitle>Gesamtsieger</CardTitle>
-            <CardDescription>{tournament.name}</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl font-semibold">{champion}</p>
-          </CardContent>
+        <Card className="relative overflow-hidden border-amber-200 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-950/20">
+          <ConfettiCorner />
+          <div className="relative p-6">
+            <p className="text-lg">
+              Wir gratulieren{" "}
+              <span className="font-semibold text-amber-700 dark:text-amber-400">
+                {champion}
+              </span>{" "}
+              als Sieger des {tournament.name}.
+            </p>
+          </div>
         </Card>
       ) : null}
       <ParticipantsSection
@@ -58,6 +55,57 @@ export async function TournamentDone({
         profileId={profile?.id}
       />
     </div>
+  );
+}
+
+function ConfettiCorner() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 96 96"
+      className="pointer-events-none absolute right-0 top-0 h-24 w-24 opacity-70"
+    >
+      <rect
+        x="74"
+        y="10"
+        width="6"
+        height="6"
+        rx="1"
+        fill="#f59e0b"
+        transform="rotate(20 77 13)"
+      />
+      <rect
+        x="86"
+        y="28"
+        width="5"
+        height="5"
+        rx="1"
+        fill="#fbbf24"
+        transform="rotate(-18 88 30)"
+      />
+      <rect
+        x="60"
+        y="6"
+        width="4"
+        height="4"
+        rx="1"
+        fill="#d97706"
+        transform="rotate(35 62 8)"
+      />
+      <rect
+        x="68"
+        y="40"
+        width="5"
+        height="5"
+        rx="1"
+        fill="#fbbf24"
+        transform="rotate(12 70 42)"
+      />
+      <circle cx="58" cy="24" r="2.5" fill="#fcd34d" />
+      <circle cx="82" cy="46" r="2" fill="#f59e0b" />
+      <circle cx="90" cy="14" r="2" fill="#fcd34d" />
+      <circle cx="48" cy="14" r="1.8" fill="#fbbf24" />
+    </svg>
   );
 }
 

--- a/src/components/uebersicht/tournament-done.tsx
+++ b/src/components/uebersicht/tournament-done.tsx
@@ -1,12 +1,103 @@
-export function TournamentDone() {
-  return (
-    <>
-      <p className="mt-2 text-lg text-muted-foreground">
-        Das letzte Turnier ist abgeschlossen.
-      </p>
-      <p className="mt-1 text-sm text-muted-foreground">
-        Wir danken dir für deine Teilnahme und freuen uns auf das nächste Mal!
-      </p>
-    </>
+import {
+  getAllGroupNamesByTournamentId,
+  getParticipantsInGroup,
+} from "@/db/repositories/game";
+import { getStandings } from "@/services/standings";
+import { StandingsDisplay } from "@/components/standings/standings-display";
+import { Card, CardContent } from "@/components/ui/card";
+import { Tournament } from "@/db/types/tournament";
+import { Trophy } from "lucide-react";
+import { auth } from "@/auth/utils";
+import { getProfileByUserId } from "@/db/repositories/profile";
+import { ParticipantsSection } from "./participants-section";
+
+export async function TournamentDone({
+  tournament,
+  selectedGroupId,
+  selectedRound,
+}: {
+  tournament: Pick<Tournament, "id" | "name" | "numberOfRounds">;
+  selectedGroupId?: string;
+  selectedRound?: string;
+}) {
+  const session = await auth();
+  const profile =
+    session != null ? await getProfileByUserId(session.user.id) : null;
+  const greetingName = profile?.firstName ?? "Gast";
+
+  const groups = await getAllGroupNamesByTournamentId(tournament.id);
+  const rounds = Array.from(
+    { length: tournament.numberOfRounds },
+    (_, i) => i + 1,
   );
+  const groupId = selectedGroupId ?? groups[0]?.id.toString();
+
+  // TODO(next PR): identify the A group via the new group.tier column (0 = A)
+  // instead of relying on groups[0] (first group by groupName).
+  const champion = await getChampionName(groups[0]?.id);
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">
+          Hallo, {greetingName}!
+        </h1>
+        <p className="mt-2 text-muted-foreground">
+          Das {tournament.name} ist zu Ende. Wir danken dir für deine Teilnahme
+          und freuen uns auf das nächste Mal!
+        </p>
+      </div>
+      {champion != null ? (
+        <Card className="border-yellow-300 bg-yellow-50 dark:bg-yellow-950/20">
+          <CardContent className="flex items-center gap-3 p-4">
+            <Trophy className="h-6 w-6 shrink-0 text-yellow-500" />
+            <p className="text-base font-medium">
+              Herzlichen Glückwunsch an <strong>{champion}</strong> für das
+              Gewinnen des {tournament.name}!
+            </p>
+          </CardContent>
+        </Card>
+      ) : null}
+      <ParticipantsSection
+        tournamentId={tournament.id}
+        profileId={profile?.id}
+      />
+      {groups.length > 0 && groupId != null ? (
+        <div className="space-y-4">
+          <h2 className="text-2xl font-bold tracking-tight">Rangliste</h2>
+          <StandingsDisplay
+            groups={groups}
+            rounds={rounds}
+            selectedGroupId={groupId}
+            selectedRound={selectedRound}
+            basePath="/uebersicht"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+async function getChampionName(aGroupId?: number) {
+  if (aGroupId == null) {
+    return null;
+  }
+
+  const [participants, standings] = await Promise.all([
+    getParticipantsInGroup(aGroupId),
+    getStandings(aGroupId),
+  ]);
+
+  const winnerId = standings[0]?.participantId;
+  if (winnerId == null) {
+    return null;
+  }
+
+  const winner = participants.find((participant) => participant.id === winnerId);
+  if (winner == null) {
+    return null;
+  }
+
+  const title = winner.title ? `${winner.title} ` : "";
+  return `${title}${winner.profile.firstName} ${winner.profile.lastName}`;
 }

--- a/src/components/uebersicht/tournament-done.tsx
+++ b/src/components/uebersicht/tournament-done.tsx
@@ -19,7 +19,11 @@ export async function TournamentDone({
 
   const groups = await getGroupsByTournamentId(tournament.id);
   const topGroup = groups.reduce<(typeof groups)[number] | null>(
-    (best, group) => (best == null || group.tier < best.tier ? group : best),
+    (best, group) => {
+      if (group.tier == null) return best;
+      if (best?.tier == null || group.tier < best.tier) return group;
+      return best;
+    },
     null,
   );
   const champion = await getChampionName(topGroup?.id);

--- a/src/components/uebersicht/tournament-done.tsx
+++ b/src/components/uebersicht/tournament-done.tsx
@@ -1,7 +1,5 @@
-import {
-  getAllGroupNamesByTournamentId,
-  getParticipantsInGroup,
-} from "@/db/repositories/game";
+import { getParticipantsInGroup } from "@/db/repositories/game";
+import { getGroupsByTournamentId } from "@/db/repositories/group";
 import { getStandings } from "@/services/standings";
 import { Card } from "@/components/ui/card";
 import { Tournament } from "@/db/types/tournament";
@@ -19,11 +17,12 @@ export async function TournamentDone({
     session != null ? await getProfileByUserId(session.user.id) : null;
   const greetingName = profile?.firstName ?? "Gast";
 
-  const groups = await getAllGroupNamesByTournamentId(tournament.id);
-
-  // TODO(next PR): identify the A group via the new group.tier column (0 = A)
-  // instead of relying on groups[0] (first group by groupName).
-  const champion = await getChampionName(groups[0]?.id);
+  const groups = await getGroupsByTournamentId(tournament.id);
+  const topGroup = groups.reduce<(typeof groups)[number] | null>(
+    (best, group) => (best == null || group.tier < best.tier ? group : best),
+    null,
+  );
+  const champion = await getChampionName(topGroup?.id);
 
   return (
     <div className="space-y-8">

--- a/src/components/uebersicht/tournament-done.tsx
+++ b/src/components/uebersicht/tournament-done.tsx
@@ -3,22 +3,22 @@ import {
   getParticipantsInGroup,
 } from "@/db/repositories/game";
 import { getStandings } from "@/services/standings";
-import { StandingsDisplay } from "@/components/standings/standings-display";
-import { Card, CardContent } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Tournament } from "@/db/types/tournament";
-import { Trophy } from "lucide-react";
 import { auth } from "@/auth/utils";
 import { getProfileByUserId } from "@/db/repositories/profile";
 import { ParticipantsSection } from "./participants-section";
 
 export async function TournamentDone({
   tournament,
-  selectedGroupId,
-  selectedRound,
 }: {
-  tournament: Pick<Tournament, "id" | "name" | "numberOfRounds">;
-  selectedGroupId?: string;
-  selectedRound?: string;
+  tournament: Pick<Tournament, "id" | "name">;
 }) {
   const session = await auth();
   const profile =
@@ -26,11 +26,6 @@ export async function TournamentDone({
   const greetingName = profile?.firstName ?? "Gast";
 
   const groups = await getAllGroupNamesByTournamentId(tournament.id);
-  const rounds = Array.from(
-    { length: tournament.numberOfRounds },
-    (_, i) => i + 1,
-  );
-  const groupId = selectedGroupId ?? groups[0]?.id.toString();
 
   // TODO(next PR): identify the A group via the new group.tier column (0 = A)
   // instead of relying on groups[0] (first group by groupName).
@@ -48,13 +43,13 @@ export async function TournamentDone({
         </p>
       </div>
       {champion != null ? (
-        <Card className="border-yellow-300 bg-yellow-50 dark:bg-yellow-950/20">
-          <CardContent className="flex items-center gap-3 p-4">
-            <Trophy className="h-6 w-6 shrink-0 text-yellow-500" />
-            <p className="text-base font-medium">
-              Herzlichen Glückwunsch an <strong>{champion}</strong> für das
-              Gewinnen des {tournament.name}!
-            </p>
+        <Card>
+          <CardHeader>
+            <CardTitle>Gesamtsieger</CardTitle>
+            <CardDescription>{tournament.name}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">{champion}</p>
           </CardContent>
         </Card>
       ) : null}
@@ -62,18 +57,6 @@ export async function TournamentDone({
         tournamentId={tournament.id}
         profileId={profile?.id}
       />
-      {groups.length > 0 && groupId != null ? (
-        <div className="space-y-4">
-          <h2 className="text-2xl font-bold tracking-tight">Rangliste</h2>
-          <StandingsDisplay
-            groups={groups}
-            rounds={rounds}
-            selectedGroupId={groupId}
-            selectedRound={selectedRound}
-            basePath="/uebersicht"
-          />
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/src/components/uebersicht/tournament-done.tsx
+++ b/src/components/uebersicht/tournament-done.tsx
@@ -37,9 +37,8 @@ export async function TournamentDone({
         </p>
       </div>
       {champion != null ? (
-        <Card className="relative overflow-hidden border-amber-200 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-950/20">
-          <ConfettiCorner />
-          <div className="relative p-6">
+        <Card className="border-amber-200 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-950/20">
+          <div className="p-6">
             <p className="text-lg">
               Wir gratulieren{" "}
               <span className="font-semibold text-amber-700 dark:text-amber-400">
@@ -55,57 +54,6 @@ export async function TournamentDone({
         profileId={profile?.id}
       />
     </div>
-  );
-}
-
-function ConfettiCorner() {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 96 96"
-      className="pointer-events-none absolute right-0 top-0 h-24 w-24 opacity-70"
-    >
-      <rect
-        x="74"
-        y="10"
-        width="6"
-        height="6"
-        rx="1"
-        fill="#f59e0b"
-        transform="rotate(20 77 13)"
-      />
-      <rect
-        x="86"
-        y="28"
-        width="5"
-        height="5"
-        rx="1"
-        fill="#fbbf24"
-        transform="rotate(-18 88 30)"
-      />
-      <rect
-        x="60"
-        y="6"
-        width="4"
-        height="4"
-        rx="1"
-        fill="#d97706"
-        transform="rotate(35 62 8)"
-      />
-      <rect
-        x="68"
-        y="40"
-        width="5"
-        height="5"
-        rx="1"
-        fill="#fbbf24"
-        transform="rotate(12 70 42)"
-      />
-      <circle cx="58" cy="24" r="2.5" fill="#fcd34d" />
-      <circle cx="82" cy="46" r="2" fill="#f59e0b" />
-      <circle cx="90" cy="14" r="2" fill="#fcd34d" />
-      <circle cx="48" cy="14" r="1.8" fill="#fbbf24" />
-    </svg>
   );
 }
 

--- a/src/db/repositories/tournament.ts
+++ b/src/db/repositories/tournament.ts
@@ -44,3 +44,10 @@ export async function getLatestTournament() {
     orderBy: (tournament, { desc }) => [desc(tournament.createdAt)],
   });
 }
+
+export async function getMostRecentDoneTournament() {
+  return await db.query.tournament.findFirst({
+    where: (tournament, { eq }) => eq(tournament.stage, "done"),
+    orderBy: (tournament, { desc }) => [desc(tournament.startDate)],
+  });
+}

--- a/src/db/schema/group.ts
+++ b/src/db/schema/group.ts
@@ -13,6 +13,7 @@ export const group = pgTable(
 
     groupNumber: integer("group_number").notNull(),
     groupName: text("group_name").notNull(),
+    tier: integer("tier").notNull().default(0),
     dayOfWeek: matchDay("day_of_week"),
     tournamentId: integer("tournament_id").notNull(),
 

--- a/src/db/schema/group.ts
+++ b/src/db/schema/group.ts
@@ -13,7 +13,7 @@ export const group = pgTable(
 
     groupNumber: integer("group_number").notNull(),
     groupName: text("group_name").notNull(),
-    tier: integer("tier").notNull().default(0),
+    tier: integer("tier"),
     dayOfWeek: matchDay("day_of_week"),
     tournamentId: integer("tournament_id").notNull(),
 

--- a/src/db/schema/participant.ts
+++ b/src/db/schema/participant.ts
@@ -37,6 +37,8 @@ export const participant = pgTable(
 
     entryFeePayed: boolean("entry_fee_payed"),
 
+    exercisePromotionRight: boolean("exercise_promotion_right"),
+
     ...timestamps,
   },
   (table) => [unique().on(table.tournamentId, table.profileId)],

--- a/src/lib/groups.ts
+++ b/src/lib/groups.ts
@@ -1,0 +1,3 @@
+export function tierLetter(tier: number): string {
+  return String.fromCharCode(65 + tier);
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -47,6 +47,7 @@ export function buildResultsViewUrl(params: {
   slug: string;
   groupId?: string;
   round?: string;
+  basePath?: string;
 }): string {
   const searchParams = new URLSearchParams();
 
@@ -58,8 +59,6 @@ export function buildResultsViewUrl(params: {
   }
 
   const query = searchParams.toString();
-  return tournamentPath(
-    params.slug,
-    query ? `/rangliste?${query}` : "/rangliste",
-  );
+  const basePath = params.basePath ?? "/rangliste";
+  return tournamentPath(params.slug, query ? `${basePath}?${query}` : basePath);
 }

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -47,7 +47,6 @@ export function buildResultsViewUrl(params: {
   slug: string;
   groupId?: string;
   round?: string;
-  basePath?: string;
 }): string {
   const searchParams = new URLSearchParams();
 
@@ -59,6 +58,8 @@ export function buildResultsViewUrl(params: {
   }
 
   const query = searchParams.toString();
-  const basePath = params.basePath ?? "/rangliste";
-  return tournamentPath(params.slug, query ? `${basePath}?${query}` : basePath);
+  return tournamentPath(
+    params.slug,
+    query ? `/rangliste?${query}` : "/rangliste",
+  );
 }

--- a/src/schema/participant.ts
+++ b/src/schema/participant.ts
@@ -41,6 +41,7 @@ export const participantFormSchema = z
     }),
     secondaryMatchDays: z.array(z.enum(availableMatchDays)),
     notAvailableDays: z.array(z.date()).max(5, "Maximal 5 Tage").optional(),
+    exercisePromotionRight: z.boolean().optional(),
   })
   .refine(
     (data) => {

--- a/src/services/promotion.ts
+++ b/src/services/promotion.ts
@@ -24,7 +24,7 @@ export const getPromotionTargetsForPreviousEdition = cache(
 
     const groups = await getGroupsByTournamentId(previousTournament.id);
     for (const group of groups) {
-      if (group.tier < 1) {
+      if (group.tier == null || group.tier < 1) {
         continue;
       }
 

--- a/src/services/promotion.ts
+++ b/src/services/promotion.ts
@@ -1,0 +1,65 @@
+import { cache } from "react";
+import { getGroupsByTournamentId } from "@/db/repositories/group";
+import { getParticipantsInGroup } from "@/db/repositories/game";
+import { getMostRecentDoneTournament } from "@/db/repositories/tournament";
+import { getStandings } from "@/services/standings";
+import { tierLetter } from "@/lib/groups";
+
+export type PromotionEligibility = {
+  wonGroupName: string;
+  wonGroupTier: number;
+  targetTier: number;
+  targetTierLetter: string;
+  targetIsAGroup: boolean;
+};
+
+export const getPromotionTargetsForPreviousEdition = cache(
+  async (): Promise<Map<number, PromotionEligibility>> => {
+    const targets = new Map<number, PromotionEligibility>();
+
+    const previousTournament = await getMostRecentDoneTournament();
+    if (!previousTournament) {
+      return targets;
+    }
+
+    const groups = await getGroupsByTournamentId(previousTournament.id);
+    for (const group of groups) {
+      if (group.tier < 1) {
+        continue;
+      }
+
+      const [participants, standings] = await Promise.all([
+        getParticipantsInGroup(group.id),
+        getStandings(group.id),
+      ]);
+
+      const winnerParticipantId = standings[0]?.participantId;
+      if (winnerParticipantId == null) {
+        continue;
+      }
+
+      const winner = participants.find((p) => p.id === winnerParticipantId);
+      if (!winner) {
+        continue;
+      }
+
+      const targetTier = group.tier - 1;
+      targets.set(winner.profileId, {
+        wonGroupName: group.groupName,
+        wonGroupTier: group.tier,
+        targetTier,
+        targetTierLetter: tierLetter(targetTier),
+        targetIsAGroup: targetTier === 0,
+      });
+    }
+
+    return targets;
+  },
+);
+
+export async function getPromotionEligibility(
+  profileId: number,
+): Promise<PromotionEligibility | null> {
+  const targets = await getPromotionTargetsForPreviousEdition();
+  return targets.get(profileId) ?? null;
+}

--- a/src/services/promotion.ts
+++ b/src/services/promotion.ts
@@ -33,13 +33,15 @@ export const getPromotionTargetsForPreviousEdition = cache(
         getStandings(group.id),
       ]);
 
-      const winnerParticipantId = standings[0]?.participantId;
-      if (winnerParticipantId == null) {
+      const winnerStats = standings[0];
+      if (winnerStats == null || winnerStats.gamesPlayed === 0) {
         continue;
       }
 
-      const winner = participants.find((p) => p.id === winnerParticipantId);
-      if (!winner) {
+      const winner = participants.find(
+        (p) => p.id === winnerStats.participantId,
+      );
+      if (winner == null || winner.deletedAt != null) {
         continue;
       }
 


### PR DESCRIPTION
Ergänzt die Funktionalität des Aufstieges.

Jeder Spieler, der eine Gruppe gewonnen hat (außer A), hat in der Anmeldung eine Abfrage zu dem Aufstieg (ja/ nein)
Der einzige Downstream Effekt ist ein Kronenicon mit Hover "Gruppe X gewonnen" und der Admin berücksichtigt dieses Recht dann manuell
<img width="2144" height="732" alt="grafik" src="https://github.com/user-attachments/assets/8823cc58-f13d-4bba-a077-0bc5bb3ce498" />

<img width="1952" height="1734" alt="grafik" src="https://github.com/user-attachments/assets/55d2d361-32e1-4594-8196-0fa5f47cadb1" />

Mobile:
<img width="882" height="1116" alt="grafik" src="https://github.com/user-attachments/assets/b89bc3f1-44e5-4ebf-8a29-52744c8a86eb" />
