### PR TITLE
fix: FIDE-Lookup, vereinslose Spieler & Dokument-Caching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Project conventions for Claude
+
+## Package manager
+Always use `bun` — never `npm` or `npx`.
+
+```
+bun run dev
+bun run build
+bun run test
+bun add <package>
+```
+
+## Next.js version
+Project is on **15.1.9**. `experimental.dynamicIO` and `"use cache"` are not available — they require canary / Next.js 16. Use `unstable_cache` from `next/cache` for caching.

--- a/drizzle/0024_large_medusa.sql
+++ b/drizzle/0024_large_medusa.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "participant" ADD COLUMN "birth_date" date;

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,1898 @@
+{
+  "id": "adcdbf6d-e481-4da0-a34f-5bc77a8db0e8",
+  "prevId": "5ef7ef92-fa74-4501-8171-6309eeb7ebcc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "white_player_id": {
+          "name": "white_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "black_player_id": {
+          "name": "black_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pgn_id": {
+          "name": "pgn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_number": {
+          "name": "board_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_postponement": {
+      "name": "game_postponement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_postponement_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponing_participant_id": {
+          "name": "postponing_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponed_by_profile_id": {
+          "name": "postponed_by_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group": {
+      "name": "group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "group_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_tournament_id_group_number_pk": {
+          "name": "group_tournament_id_group_number_pk",
+          "columns": [
+            "tournament_id",
+            "group_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.juror": {
+      "name": "juror",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "juror_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "juror_tournament_id_profile_id_unique": {
+          "name": "juror_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_match_entering_helper": {
+      "name": "group_match_entering_helper",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_entering_helper_id": {
+          "name": "match_entering_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_match_entering_helper_group_id_match_entering_helper_id_pk": {
+          "name": "group_match_entering_helper_group_id_match_entering_helper_id_pk",
+          "columns": [
+            "group_id",
+            "match_entering_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_entering_helper": {
+      "name": "match_entering_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "match_entering_helper_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_groups_to_enter": {
+          "name": "number_of_groups_to_enter",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_entering_helper_tournament_id_profile_id_unique": {
+          "name": "match_entering_helper_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday": {
+      "name": "matchday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "matchday_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_week_id": {
+          "name": "tournament_week_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_needed": {
+          "name": "referee_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_game": {
+      "name": "matchday_game",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_game_matchday_id_game_id_pk": {
+          "name": "matchday_game_matchday_id_game_id_pk",
+          "columns": [
+            "matchday_id",
+            "game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_referee": {
+      "name": "matchday_referee",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_id": {
+          "name": "referee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_referee_matchday_id_referee_id_pk": {
+          "name": "matchday_referee_matchday_id_referee_id_pk",
+          "columns": [
+            "matchday_id",
+            "referee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_setup_helper": {
+      "name": "matchday_setup_helper",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_helper_id": {
+          "name": "setup_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_setup_helper_matchday_id_setup_helper_id_pk": {
+          "name": "matchday_setup_helper_matchday_id_setup_helper_id_pk",
+          "columns": [
+            "matchday_id",
+            "setup_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant": {
+      "name": "participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "participant_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chess_club": {
+          "name": "chess_club",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'m'"
+        },
+        "dwz_rating": {
+          "name": "dwz_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_rating": {
+          "name": "fide_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_club_id": {
+          "name": "zps_club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_player_id": {
+          "name": "zps_player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_days": {
+          "name": "secondary_match_days",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "not_available_days": {
+          "name": "not_available_days",
+          "type": "date[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_fee_payed": {
+          "name": "entry_fee_payed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exercise_promotion_right": {
+          "name": "exercise_promotion_right",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participant_tournament_id_profile_id_unique": {
+          "name": "participant_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_group": {
+      "name": "participant_group",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_position": {
+          "name": "group_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "participant_group_group_id_participant_id_group_position_pk": {
+          "name": "participant_group_group_id_participant_id_group_position_pk",
+          "columns": [
+            "group_id",
+            "participant_id",
+            "group_position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pgn": {
+      "name": "pgn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pgn_game_id_unique": {
+          "name": "pgn_game_id_unique",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pgn_game_id_game_id_fk": {
+          "name": "pgn_game_id_game_id_fk",
+          "tableFrom": "pgn",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "profile_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_title": {
+          "name": "academic_title",
+          "type": "academic_title",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_email_unique": {
+          "name": "profile_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referee": {
+      "name": "referee",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "referee_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "referee_tournament_id_profile_id_unique": {
+          "name": "referee_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_helper": {
+      "name": "setup_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "setup_helper_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "setup_helper_tournament_id_profile_id_unique": {
+          "name": "setup_helper_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament": {
+      "name": "tournament",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_rounds": {
+          "name": "number_of_rounds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_registration_date": {
+          "name": "end_registration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_announcement_offset_days": {
+          "name": "group_announcement_offset_days",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_limit": {
+          "name": "time_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_clocks_digital": {
+          "name": "all_clocks_digital",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tie_break_method": {
+          "name": "tie_break_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "software": {
+          "name": "software",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "tournament_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registration'"
+        },
+        "game_start_time": {
+          "name": "game_start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'19:00:00'"
+        },
+        "organizer_profile_id": {
+          "name": "organizer_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "one_tournament_in_registration": {
+          "name": "one_tournament_in_registration",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tournament\".\"stage\" = 'registration'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_slug_unique": {
+          "name": "tournament_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_week": {
+      "name": "tournament_week",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_week_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_week_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "week_number": {
+          "name": "week_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainer": {
+      "name": "trainer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "trainer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trainer_tournament_id_profile_id_unique": {
+          "name": "trainer_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.academic_title": {
+      "name": "academic_title",
+      "schema": "public",
+      "values": [
+        "Dr."
+      ]
+    },
+    "public.result": {
+      "name": "result",
+      "schema": "public",
+      "values": [
+        "1:0",
+        "0:1",
+        "½-½",
+        "+:-",
+        "-:+",
+        "-:-",
+        "0-½",
+        "½-0"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "m",
+        "f"
+      ]
+    },
+    "public.match_day": {
+      "name": "match_day",
+      "schema": "public",
+      "values": [
+        "tuesday",
+        "thursday",
+        "friday"
+      ]
+    },
+    "public.tournament_stage": {
+      "name": "tournament_stage",
+      "schema": "public",
+      "values": [
+        "registration",
+        "running",
+        "done"
+      ]
+    },
+    "public.tournament_week_status": {
+      "name": "tournament_week_status",
+      "schema": "public",
+      "values": [
+        "regular",
+        "catch-up"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1782664183364,
       "tag": "0023_silent_wither",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1782669876082,
+      "tag": "0024_large_medusa",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  experimental: {
-    dynamicIO: true,
-  },
   async redirects() {
     return [
       {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
   async redirects() {
     return [
       {
@@ -13,7 +16,8 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        source: "/((?!.*(?:ausschreibung|uhren|anleitung|turnierordnung)).*)",
+        source:
+          "/((?!(?:ausschreibung|turnierordnung|uhren|anleitung)(?:\\/|$)|turniere\\/[^\\/]+\\/(?:ausschreibung|turnierordnung)(?:\\/|$)).*)",
         headers: [
           {
             key: "Cross-Origin-Embedder-Policy",

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        source: "/((?!ausschreibung|uhren|anleitung|turnierordnung).*)",
+        source: "/((?!.*(?:ausschreibung|uhren|anleitung|turnierordnung)).*)",
         headers: [
           {
             key: "Cross-Origin-Embedder-Policy",

--- a/src/actions/document.ts
+++ b/src/actions/document.ts
@@ -1,0 +1,26 @@
+"use server";
+
+const DOCUMENTS_BASE_URL = "https://klubturnier.hsk1830.de/pdfs";
+
+async function documentExists(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      method: "HEAD",
+      next: { revalidate: 3600 },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function getTournamentDocumentAvailability(slug: string): Promise<{
+  ausschreibung: boolean;
+  turnierordnung: boolean;
+}> {
+  const [ausschreibung, turnierordnung] = await Promise.all([
+    documentExists(`${DOCUMENTS_BASE_URL}/${slug}/ausschreibung.pdf`),
+    documentExists(`${DOCUMENTS_BASE_URL}/${slug}/turnierordnung.pdf`),
+  ]);
+  return { ausschreibung, turnierordnung };
+}

--- a/src/actions/document.ts
+++ b/src/actions/document.ts
@@ -1,4 +1,4 @@
-import { unstable_cacheLife } from "next/cache";
+import { unstable_cache } from "next/cache";
 
 const DOCUMENTS_BASE_URL = "https://klubturnier.hsk1830.de/pdfs";
 
@@ -11,14 +11,14 @@ async function documentExists(url: string): Promise<boolean> {
   }
 }
 
-export async function getTournamentDocumentAvailability(
-  slug: string,
-): Promise<{ ausschreibung: boolean; turnierordnung: boolean }> {
-  "use cache";
-  unstable_cacheLife("hours");
-  const [ausschreibung, turnierordnung] = await Promise.all([
-    documentExists(`${DOCUMENTS_BASE_URL}/${slug}/ausschreibung.pdf`),
-    documentExists(`${DOCUMENTS_BASE_URL}/${slug}/turnierordnung.pdf`),
-  ]);
-  return { ausschreibung, turnierordnung };
-}
+export const getTournamentDocumentAvailability = unstable_cache(
+  async (slug: string): Promise<{ ausschreibung: boolean; turnierordnung: boolean }> => {
+    const [ausschreibung, turnierordnung] = await Promise.all([
+      documentExists(`${DOCUMENTS_BASE_URL}/${slug}/ausschreibung.pdf`),
+      documentExists(`${DOCUMENTS_BASE_URL}/${slug}/turnierordnung.pdf`),
+    ]);
+    return { ausschreibung, turnierordnung };
+  },
+  ["tournament-document-availability"],
+  { revalidate: 3600 },
+);

--- a/src/actions/document.ts
+++ b/src/actions/document.ts
@@ -1,23 +1,21 @@
-"use server";
+import { unstable_cacheLife } from "next/cache";
 
 const DOCUMENTS_BASE_URL = "https://klubturnier.hsk1830.de/pdfs";
 
 async function documentExists(url: string): Promise<boolean> {
   try {
-    const response = await fetch(url, {
-      method: "HEAD",
-      next: { revalidate: 3600 },
-    });
+    const response = await fetch(url, { method: "HEAD" });
     return response.ok;
   } catch {
     return false;
   }
 }
 
-export async function getTournamentDocumentAvailability(slug: string): Promise<{
-  ausschreibung: boolean;
-  turnierordnung: boolean;
-}> {
+export async function getTournamentDocumentAvailability(
+  slug: string,
+): Promise<{ ausschreibung: boolean; turnierordnung: boolean }> {
+  "use cache";
+  unstable_cacheLife("hours");
   const [ausschreibung, turnierordnung] = await Promise.all([
     documentExists(`${DOCUMENTS_BASE_URL}/${slug}/ausschreibung.pdf`),
     documentExists(`${DOCUMENTS_BASE_URL}/${slug}/turnierordnung.pdf`),

--- a/src/actions/fide-report.ts
+++ b/src/actions/fide-report.ts
@@ -17,8 +17,8 @@ import { calculateStandings } from "@/lib/standings";
 import { DateTime } from "luxon";
 import invariant from "tiny-invariant";
 import { match } from "ts-pattern";
-import { getDwzAndEloByZps } from "./participant";
 import { getRefereeOfGroup } from "@/services/referee";
+import { getFideProfile } from "@/lib/fide/profile";
 
 export const generateFideReportFile = action(
   async (groupId: number, month: number) => {
@@ -276,17 +276,14 @@ export const generateFideReportFile = action(
 );
 
 async function getCurrentElo(participant: Participant) {
-  if (participant.zpsPlayerId == null || participant.zpsClubId == null) {
-    invariant(participant.fideRating != null, "FIDE rating cannot be null");
-    return participant.fideRating;
+  if (participant.fideId != null) {
+    const fideProfile = await getFideProfile(participant.fideId);
+    if (fideProfile?.fideRating != null) {
+      return fideProfile.fideRating;
+    }
   }
-  const result = await getDwzAndEloByZps(
-    participant.zpsPlayerId,
-    participant.zpsClubId,
-  );
-  invariant(result != null, "Current FIDE rating could not be retrieved");
-  invariant(result.fideRating != null, "Retrieved FIDE rating cannot be null");
-  return result.fideRating;
+  invariant(participant.fideRating != null, "FIDE rating cannot be null");
+  return participant.fideRating;
 }
 
 function mapResult(result: GameResult, isWhite: boolean): Result["result"] {

--- a/src/actions/participant.ts
+++ b/src/actions/participant.ts
@@ -11,9 +11,24 @@ import { getProfileByUserId } from "@/db/repositories/profile";
 import { getParticipantsWithZpsIdsByTournamentId } from "@/db/repositories/participant";
 import { getPromotionEligibility } from "@/services/promotion";
 import { and, eq } from "drizzle-orm";
-import { DEFAULT_CLUB_LABEL } from "@/constants/constants";
+import {
+  CLUBLESS_KEY,
+  CLUBLESS_LABEL,
+  DEFAULT_CLUB_KEY,
+  DEFAULT_CLUB_LABEL,
+} from "@/constants/constants";
 import { revalidatePath } from "next/cache";
 import { action } from "@/lib/actions";
+import { getFideProfile } from "@/lib/fide/profile";
+
+function parseRating(value: string | undefined): number | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const rating = Number(trimmed);
+  return Number.isFinite(rating) && rating > 0 ? rating : null;
+}
 
 export async function createParticipant(
   tournamentId: number,
@@ -27,9 +42,16 @@ export async function createParticipant(
       throw new Error("Schachverein ist erforderlich");
     }
     chessClub = data.chessClub;
+  } else if (data.chessClubType === CLUBLESS_KEY) {
+    chessClub = CLUBLESS_LABEL;
   } else {
     chessClub = DEFAULT_CLUB_LABEL;
   }
+
+  const entryFeePayed = data.chessClubType === DEFAULT_CLUB_KEY ? null : false;
+  const birthYear = data.birthDate
+    ? data.birthDate.getFullYear()
+    : data.birthYear;
 
   const tournament = await getTournamentById(tournamentId);
   invariant(
@@ -52,35 +74,39 @@ export async function createParticipant(
       tournamentId: tournament.id,
       chessClub,
       title: data.title === "noTitle" ? null : data.title,
+      gender: data.gender,
       dwzRating: data.dwzRating,
       fideRating: data.fideRating,
       fideId: data.fideId,
       nationality: data.nationality,
-      birthYear: data.birthYear,
+      birthYear,
+      birthDate: data.birthDate,
       preferredMatchDay: data.preferredMatchDay,
       secondaryMatchDays: data.secondaryMatchDays,
       notAvailableDays: data.notAvailableDays,
       zpsClubId: data.zpsClub,
       zpsPlayerId: data.zpsPlayer,
-      entryFeePayed: data.chessClubType === "other" ? false : null,
+      entryFeePayed,
       exercisePromotionRight,
     })
     .onConflictDoUpdate({
       target: [participant.tournamentId, participant.profileId],
       set: {
         chessClub,
+        gender: data.gender,
         dwzRating: data.dwzRating,
         fideRating: data.fideRating,
         fideId: data.fideId,
         nationality: data.nationality,
         title: data.title === "noTitle" ? null : data.title,
-        birthYear: data.birthYear,
+        birthYear,
+        birthDate: data.birthDate,
         preferredMatchDay: data.preferredMatchDay,
         secondaryMatchDays: data.secondaryMatchDays,
         notAvailableDays: data.notAvailableDays,
         zpsClubId: data.zpsClub,
         zpsPlayerId: data.zpsPlayer,
-        entryFeePayed: data.chessClubType === "other" ? false : null,
+        entryFeePayed,
         exercisePromotionRight,
       },
     });
@@ -124,6 +150,8 @@ export async function getParticipantEloData(
   fideId: string | null;
   zpsClub: string;
   zpsPlayer: string;
+  gender: "m" | "f" | null;
+  birthYear: number | null;
 } | null> {
   await authWithRedirect();
 
@@ -172,25 +200,28 @@ export async function getParticipantEloData(
     return null;
   }
 
-  const ratingSchema = z.coerce.number();
-  const fideRating = ratingSchema.safeParse(playerFields[7]);
-  const dwzRating = ratingSchema.safeParse(playerFields[4]);
+  const dwzRating = parseRating(playerFields[4]);
+  const fideId = playerFields[6] || null;
+
+  const fideProfile = fideId ? await getFideProfile(fideId) : null;
 
   return {
-    title: playerFields[8] || null,
+    title: fideProfile?.title ?? (playerFields[8] || null),
     nationality: playerFields[9],
-    fideRating: fideRating.success ? fideRating.data : null,
-    dwzRating: dwzRating.success ? dwzRating.data : null,
-    fideId: playerFields[6] || null,
+    fideRating: fideProfile?.fideRating ?? null,
+    dwzRating,
+    fideId,
     zpsClub: clubFields[4],
     zpsPlayer: clubFields[5],
+    gender: fideProfile?.gender ?? null,
+    birthYear: fideProfile?.birthYear ?? null,
   };
 }
 
-export async function getDwzAndEloByZps(
+export async function getDwzAndFideIdByZps(
   zpsPlayerId: string,
   zpsClubId: string,
-) {
+): Promise<{ dwzRating: number | null; fideId: string | null } | null> {
   const clubData = await fetch(
     `https://www.schachbund.de/php/dewis/verein.php?zps=${zpsClubId}&format=csv`,
   );
@@ -212,13 +243,9 @@ export async function getDwzAndEloByZps(
     return null;
   }
 
-  const ratingSchema = z.coerce.number();
-  const dwzRating = ratingSchema.safeParse(clubFields[7]);
-  const fideRating = ratingSchema.safeParse(clubFields[12]);
-
   return {
-    dwzRating: dwzRating.success ? dwzRating.data : null,
-    fideRating: fideRating.success ? fideRating.data : null,
+    dwzRating: parseRating(clubFields[7]),
+    fideId: clubFields[11]?.trim() || null,
   };
 }
 
@@ -251,21 +278,32 @@ export const updateAllParticipantRatings = action(
 
     for (const participantData of participants) {
       try {
-        const eloData = await getDwzAndEloByZps(
+        const dewisData = await getDwzAndFideIdByZps(
           participantData.zpsPlayerId!,
           participantData.zpsClubId!,
         );
-        if (!eloData) {
+
+        const fideId = participantData.fideId ?? dewisData?.fideId ?? null;
+        const fideRating = fideId
+          ? ((await getFideProfile(fideId))?.fideRating ?? null)
+          : null;
+
+        const values: { dwzRating?: number; fideRating?: number } = {};
+        if (dewisData?.dwzRating != null) {
+          values.dwzRating = dewisData.dwzRating;
+        }
+        if (fideRating != null) {
+          values.fideRating = fideRating;
+        }
+
+        if (Object.keys(values).length === 0) {
           failed++;
           continue;
         }
 
         await db
           .update(participant)
-          .set({
-            dwzRating: eloData.dwzRating,
-            fideRating: eloData.fideRating,
-          })
+          .set(values)
           .where(eq(participant.id, participantData.id));
 
         updated++;

--- a/src/actions/participant.ts
+++ b/src/actions/participant.ts
@@ -284,16 +284,24 @@ export const updateAllParticipantRatings = action(
         );
 
         const fideId = participantData.fideId ?? dewisData?.fideId ?? null;
-        const fideRating = fideId
-          ? ((await getFideProfile(fideId))?.fideRating ?? null)
-          : null;
 
-        const values: { dwzRating?: number; fideRating?: number } = {};
+        const values: {
+          dwzRating?: number;
+          fideRating?: number;
+          fideId?: string;
+        } = {};
+
         if (dewisData?.dwzRating != null) {
           values.dwzRating = dewisData.dwzRating;
         }
-        if (fideRating != null) {
-          values.fideRating = fideRating;
+        if (fideId != null) {
+          const profile = await getFideProfile(fideId);
+          if (profile?.fideRating != null) {
+            values.fideRating = profile.fideRating;
+          }
+          if (!participantData.fideId) {
+            values.fideId = fideId;
+          }
         }
 
         if (Object.keys(values).length === 0) {

--- a/src/app/(main)/turniere/[slug]/partien/page.tsx
+++ b/src/app/(main)/turniere/[slug]/partien/page.tsx
@@ -48,7 +48,8 @@ export default async function Page({
         </div>
         <div className="text-sm text-gray-600">
           <p className="mb-2">
-            Du findest die Turniere der vorherigen Jahre unter:{" "}
+            Turniere ab 2025 findest du links über das Dropdown in der
+            Seitenleiste. Die Turniere der vorherigen Jahre findest du unter:{" "}
             <a
               href="https://hsk1830.de/spielbetrieb/turniere/klubturnier"
               target="_blank"

--- a/src/app/(setup)/willkommen/page.tsx
+++ b/src/app/(setup)/willkommen/page.tsx
@@ -32,6 +32,7 @@ import {
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { tournamentPath } from "@/lib/navigation";
+import { getTournamentDocumentAvailability } from "@/actions/document";
 
 export default async function Page() {
   const [session, tournament] = await Promise.all([
@@ -55,6 +56,10 @@ export default async function Page() {
     redirect("/klubturnier-anmeldung");
   }
 
+  const documentAvailability = tournament
+    ? await getTournamentDocumentAvailability(tournament.slug)
+    : { ausschreibung: false, turnierordnung: false };
+
   return (
     <div>
       <section className="text-center mb-8 md:mb-16 max-w-3xl mx-auto">
@@ -66,29 +71,33 @@ export default async function Page() {
         {/* Document Links */}
         {tournament && (
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link
-            href={tournamentPath(tournament.slug, "/ausschreibung")}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group flex items-center gap-3 px-4 py-3 border border-border rounded-lg hover:border-primary hover:bg-primary/5 transition-all duration-200"
-          >
-            <BookTextIcon className="h-5 w-5" />
-            <span className="font-medium">Ausschreibung</span>
-            <ExternalLinkIcon className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
-          </Link>
+            {documentAvailability.ausschreibung && (
+              <Link
+                href={tournamentPath(tournament.slug, "/ausschreibung")}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-3 px-4 py-3 border border-border rounded-lg hover:border-primary hover:bg-primary/5 transition-all duration-200"
+              >
+                <BookTextIcon className="h-5 w-5" />
+                <span className="font-medium">Ausschreibung</span>
+                <ExternalLinkIcon className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
+              </Link>
+            )}
 
-          <Link
-            href={tournamentPath(tournament.slug, "/turnierordnung")}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group flex items-center gap-3 px-4 py-3 border border-border rounded-lg hover:border-primary hover:bg-primary/5 transition-all duration-200"
-          >
-            <BookTextIcon className="h-5 w-5" />
-            <span className="font-medium">Turnierordnung</span>
-            <ExternalLinkIcon className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
-          </Link>
+            {documentAvailability.turnierordnung && (
+              <Link
+                href={tournamentPath(tournament.slug, "/turnierordnung")}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-3 px-4 py-3 border border-border rounded-lg hover:border-primary hover:bg-primary/5 transition-all duration-200"
+              >
+                <BookTextIcon className="h-5 w-5" />
+                <span className="font-medium">Turnierordnung</span>
+                <ExternalLinkIcon className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
+              </Link>
+            )}
 
-          <Dialog>
+            <Dialog>
             <DialogTrigger asChild>
               <div className="group flex items-center gap-3 px-4 py-3 border border-border rounded-lg hover:border-primary hover:bg-primary/5 transition-all duration-200 cursor-pointer">
                 <BookTextIcon className="h-5 w-5" />

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -263,34 +263,59 @@ export function ParticipateForm({
         )}
 
         {chessClubType === CLUBLESS_KEY && (
-          <FormField
-            control={form.control}
-            name="birthDate"
-            render={({ field }) => (
-              <FormItem className="w-full sm:w-64">
-                <FormLabel required>Geburtsdatum</FormLabel>
-                <FormControl>
-                  <Input
-                    type="date"
-                    max={format(new Date(), "yyyy-MM-dd")}
-                    value={field.value ? format(field.value, "yyyy-MM-dd") : ""}
-                    onChange={(e) =>
-                      field.onChange(
-                        e.target.value
-                          ? new Date(`${e.target.value}T00:00:00`)
-                          : undefined,
-                      )
-                    }
-                  />
-                </FormControl>
-                <FormDescription>
-                  Für vereinslose Spieler benötigt der DSB das exakte
-                  Geburtsdatum für die FIDE- und DWZ-Wertung.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          <div className="flex gap-4">
+            <FormField
+              control={form.control}
+              name="gender"
+              render={({ field }) => (
+                <FormItem className="w-32">
+                  <FormLabel required>Geschlecht</FormLabel>
+                  <FormControl>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Geschlecht" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="m">Männlich</SelectItem>
+                        <SelectItem value="f">Weiblich</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="birthDate"
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel required>Geburtsdatum</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="date"
+                      max={format(new Date(), "yyyy-MM-dd")}
+                      value={
+                        field.value ? format(field.value, "yyyy-MM-dd") : ""
+                      }
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value
+                            ? new Date(`${e.target.value}T00:00:00`)
+                            : undefined,
+                        )
+                      }
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Für vereinslose Spieler benötigt der DSB das exakte
+                    Geburtsdatum für die FIDE- und DWZ-Wertung.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
         )}
 
         {chessClubType != null ? (
@@ -320,30 +345,6 @@ export function ParticipateForm({
                         <SelectItem value="WIM">WIM </SelectItem>
                         <SelectItem value="WFM">WFM </SelectItem>
                         <SelectItem value="WCM">WCM </SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="gender"
-              render={({ field }) => (
-                <FormItem className="w-32">
-                  <FormLabel>Geschlecht</FormLabel>
-                  <FormControl>
-                    <Select
-                      value={field.value}
-                      onValueChange={field.onChange}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Geschlecht" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="m">Männlich</SelectItem>
-                        <SelectItem value="f">Weiblich</SelectItem>
                       </SelectContent>
                     </Select>
                   </FormControl>

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -34,7 +34,12 @@ import { isHoliday } from "@/lib/holidays";
 import { Tournament } from "@/db/types/tournament";
 import { getParticipantEloData } from "@/actions/participant";
 import { Profile } from "@/db/types/profile";
-import { DEFAULT_CLUB_KEY, DEFAULT_CLUB_LABEL } from "@/constants/constants";
+import {
+  CLUBLESS_KEY,
+  CLUBLESS_LABEL,
+  DEFAULT_CLUB_KEY,
+  DEFAULT_CLUB_LABEL,
+} from "@/constants/constants";
 import { Switch } from "@/components/ui/switch";
 import type { PromotionEligibility } from "@/services/promotion";
 
@@ -64,11 +69,13 @@ export function ParticipateForm({
       chessClubType: initialValues?.chessClubType,
       chessClub: initialValues?.chessClub,
       title: initialValues?.title,
+      gender: initialValues?.gender,
       dwzRating: initialValues?.dwzRating,
       fideRating: initialValues?.fideRating,
       fideId: initialValues?.fideId,
       nationality: initialValues?.nationality,
       birthYear: initialValues?.birthYear,
+      birthDate: initialValues?.birthDate,
       zpsClub: initialValues?.zpsClub,
       zpsPlayer: initialValues?.zpsPlayer,
       preferredMatchDay: initialValues?.preferredMatchDay,
@@ -86,11 +93,20 @@ export function ParticipateForm({
     return isDateDisabled(date, tournament.startDate, tournament.endDate);
   };
 
-  const handleChessClubTypeChange = (value: "hsk" | "other") => {
+  const handleChessClubTypeChange = (
+    value: "hsk" | "other" | "vereinslos",
+  ) => {
     form.setValue("chessClubType", value);
 
     if (value === "other") {
       form.setValue("chessClub", "");
+      return;
+    }
+
+    if (value === CLUBLESS_KEY) {
+      form.setValue("chessClub", "");
+      form.setValue("zpsClub", undefined);
+      form.setValue("zpsPlayer", undefined);
       return;
     }
 
@@ -108,8 +124,14 @@ export function ParticipateForm({
 
       form.setValue("title", eloData.title ?? "noTitle");
 
+      if (eloData.gender) {
+        form.setValue("gender", eloData.gender);
+      }
       if (eloData.dwzRating) {
         form.setValue("dwzRating", eloData.dwzRating);
+      }
+      if (eloData.birthYear) {
+        form.setValue("birthYear", eloData.birthYear);
       }
       if (eloData.zpsClub) {
         form.setValue("zpsClub", eloData.zpsClub);
@@ -202,6 +224,9 @@ export function ParticipateForm({
                         {DEFAULT_CLUB_LABEL}
                       </SelectItem>
                       <SelectItem value="other">Anderer Verein</SelectItem>
+                      <SelectItem value={CLUBLESS_KEY}>
+                        {CLUBLESS_LABEL}
+                      </SelectItem>
                     </SelectContent>
                   </Select>
                 </FormControl>
@@ -237,6 +262,37 @@ export function ParticipateForm({
           />
         )}
 
+        {chessClubType === CLUBLESS_KEY && (
+          <FormField
+            control={form.control}
+            name="birthDate"
+            render={({ field }) => (
+              <FormItem className="w-full sm:w-64">
+                <FormLabel required>Geburtsdatum</FormLabel>
+                <FormControl>
+                  <Input
+                    type="date"
+                    max={format(new Date(), "yyyy-MM-dd")}
+                    value={field.value ? format(field.value, "yyyy-MM-dd") : ""}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value
+                          ? new Date(`${e.target.value}T00:00:00`)
+                          : undefined,
+                      )
+                    }
+                  />
+                </FormControl>
+                <FormDescription>
+                  Für vereinslose Spieler benötigt der DSB das exakte
+                  Geburtsdatum für die FIDE- und DWZ-Wertung.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+
         {chessClubType != null ? (
           <div className="flex gap-4">
             <FormField
@@ -264,6 +320,30 @@ export function ParticipateForm({
                         <SelectItem value="WIM">WIM </SelectItem>
                         <SelectItem value="WFM">WFM </SelectItem>
                         <SelectItem value="WCM">WCM </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="gender"
+              render={({ field }) => (
+                <FormItem className="w-32">
+                  <FormLabel>Geschlecht</FormLabel>
+                  <FormControl>
+                    <Select
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Geschlecht" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="m">Männlich</SelectItem>
+                        <SelectItem value="f">Weiblich</SelectItem>
                       </SelectContent>
                     </Select>
                   </FormControl>

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -263,59 +263,63 @@ export function ParticipateForm({
         )}
 
         {chessClubType === CLUBLESS_KEY && (
-          <div className="flex gap-4">
-            <FormField
-              control={form.control}
-              name="gender"
-              render={({ field }) => (
-                <FormItem className="w-32">
-                  <FormLabel required>Geschlecht</FormLabel>
-                  <FormControl>
-                    <Select value={field.value} onValueChange={field.onChange}>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Geschlecht" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="m">Männlich</SelectItem>
-                        <SelectItem value="f">Weiblich</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="birthDate"
-              render={({ field }) => (
-                <FormItem className="flex-1">
-                  <FormLabel required>Geburtsdatum</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="date"
-                      max={format(new Date(), "yyyy-MM-dd")}
-                      value={
-                        field.value ? format(field.value, "yyyy-MM-dd") : ""
-                      }
-                      onChange={(e) =>
-                        field.onChange(
-                          e.target.value
-                            ? new Date(`${e.target.value}T00:00:00`)
-                            : undefined,
-                        )
-                      }
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Für vereinslose Spieler benötigt der DSB das exakte
-                    Geburtsdatum und das Geschlecht für die FIDE- und
-                    DWZ-Wertung.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <div className="space-y-2">
+            <div className="flex gap-4">
+              <FormField
+                control={form.control}
+                name="gender"
+                render={({ field }) => (
+                  <FormItem className="w-32">
+                    <FormLabel required>Geschlecht</FormLabel>
+                    <FormControl>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Geschlecht" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="m">Männlich</SelectItem>
+                          <SelectItem value="f">Weiblich</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="birthDate"
+                render={({ field }) => (
+                  <FormItem className="flex-1">
+                    <FormLabel required>Geburtsdatum</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="date"
+                        max={format(new Date(), "yyyy-MM-dd")}
+                        value={
+                          field.value ? format(field.value, "yyyy-MM-dd") : ""
+                        }
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value
+                              ? new Date(`${e.target.value}T00:00:00`)
+                              : undefined,
+                          )
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Für vereinslose Spieler benötigt der DSB das exakte Geburtsdatum
+              und das Geschlecht für die FIDE- und DWZ-Wertung.
+            </p>
           </div>
         )}
 
@@ -397,8 +401,8 @@ export function ParticipateForm({
                   </FormControl>
                   <FormMessage />
                   <FormDescription>
-                    Wer in den A- und B-Gruppen spielen möchte, muss seine Elo
-                    angeben.
+                    Wer in den A-, B- und C-Gruppen spielen möchte, muss seine
+                    Elo angeben.
                   </FormDescription>
                 </FormItem>
               )}
@@ -520,7 +524,8 @@ export function ParticipateForm({
               <FormMessage />
               <FormDescription>
                 Wer nicht flexibel ist, könnte unter Umständen bei dem Turnier
-                nicht berücksichtigt werden.
+                nicht berücksichtigt werden oder landet in einer niedrigeren
+                Gruppe.
               </FormDescription>
             </FormItem>
           )}

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -33,6 +33,7 @@ import { cn } from "@/lib/utils";
 import { isHoliday } from "@/lib/holidays";
 import { Tournament } from "@/db/types/tournament";
 import { getParticipantEloData } from "@/actions/participant";
+import { toast } from "sonner";
 import { Profile } from "@/db/types/profile";
 import {
   CLUBLESS_KEY,
@@ -111,41 +112,49 @@ export function ParticipateForm({
     }
 
     startTransition(async () => {
-      const eloData = await getParticipantEloData(
-        profile.firstName,
-        profile.lastName,
-      );
-      if (!eloData) {
-        console.warn(
-          `No Elo data found for ${profile.firstName} ${profile.lastName}`,
+      try {
+        const eloData = await getParticipantEloData(
+          profile.firstName,
+          profile.lastName,
         );
-        return;
-      }
+        if (!eloData) {
+          toast.info(
+            `Keine Einträge zu ${profile.firstName} ${profile.lastName} im HSK-Verzeichnis gefunden. Bitte trage deine Daten manuell ein.`,
+          );
+          return;
+        }
 
-      form.setValue("title", eloData.title ?? "noTitle");
+        form.setValue("title", eloData.title ?? "noTitle");
 
-      if (eloData.gender) {
-        form.setValue("gender", eloData.gender);
-      }
-      if (eloData.dwzRating) {
-        form.setValue("dwzRating", eloData.dwzRating);
-      }
-      if (eloData.birthYear) {
-        form.setValue("birthYear", eloData.birthYear);
-      }
-      if (eloData.zpsClub) {
-        form.setValue("zpsClub", eloData.zpsClub);
-      }
-      if (eloData.zpsPlayer) {
-        form.setValue("zpsPlayer", eloData.zpsPlayer);
-      }
+        if (eloData.gender) {
+          form.setValue("gender", eloData.gender);
+        }
+        if (eloData.dwzRating) {
+          form.setValue("dwzRating", eloData.dwzRating);
+        }
+        if (eloData.birthYear) {
+          form.setValue("birthYear", eloData.birthYear);
+        }
+        if (eloData.zpsClub) {
+          form.setValue("zpsClub", eloData.zpsClub);
+        }
+        if (eloData.zpsPlayer) {
+          form.setValue("zpsPlayer", eloData.zpsPlayer);
+        }
 
-      if (eloData.fideRating && eloData.fideId) {
-        form.setValue("fideRating", eloData.fideRating);
-        form.setValue("fideId", eloData.fideId);
-        form.setValue(
-          "nationality",
-          eloData.nationality !== "?" ? eloData.nationality : undefined,
+        if (eloData.fideRating && eloData.fideId) {
+          form.setValue("fideRating", eloData.fideRating);
+          form.setValue("fideId", eloData.fideId);
+          form.setValue(
+            "nationality",
+            eloData.nationality !== "?" ? eloData.nationality : undefined,
+          );
+        }
+
+        toast.success("Deine Daten wurden aus der DSB-Datenbank übernommen.");
+      } catch {
+        toast.error(
+          "Daten konnten nicht aus der DSB-Datenbank geladen werden. Bitte trage sie manuell ein.",
         );
       }
     });

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -309,7 +309,8 @@ export function ParticipateForm({
                   </FormControl>
                   <FormDescription>
                     Für vereinslose Spieler benötigt der DSB das exakte
-                    Geburtsdatum für die FIDE- und DWZ-Wertung.
+                    Geburtsdatum und das Geschlecht für die FIDE- und
+                    DWZ-Wertung.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -502,7 +502,7 @@ export function ParticipateForm({
                 </Select>
               </FormControl>
               <FormDescription>
-                Die A-Klasse spielt nur an Freitagen
+                Die A-Gruppe spielt nur an Freitagen
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -142,9 +142,11 @@ export function ParticipateForm({
           form.setValue("zpsPlayer", eloData.zpsPlayer);
         }
 
+        if (eloData.fideId) {
+          form.setValue("fideId", eloData.fideId);
+        }
         if (eloData.fideRating && eloData.fideId) {
           form.setValue("fideRating", eloData.fideRating);
-          form.setValue("fideId", eloData.fideId);
           form.setValue(
             "nationality",
             eloData.nationality !== "?" ? eloData.nationality : undefined,

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -366,6 +366,7 @@ export function ParticipateForm({
                       max="2800"
                       step="1"
                       {...field}
+                      value={field.value ?? ""}
                     />
                   </FormControl>
                   <FormMessage />
@@ -389,6 +390,7 @@ export function ParticipateForm({
                       max="2800"
                       step="1"
                       {...field}
+                      value={field.value ?? ""}
                     />
                   </FormControl>
                   <FormMessage />
@@ -412,7 +414,12 @@ export function ParticipateForm({
                 <FormItem>
                   <FormLabel required>FIDE ID</FormLabel>
                   <FormControl>
-                    <Input id="fideId" placeholder="10245154" {...field} />
+                    <Input
+                      id="fideId"
+                      placeholder="10245154"
+                      {...field}
+                      value={field.value ?? ""}
+                    />
                   </FormControl>
                   <FormDescription>
                     <a
@@ -461,6 +468,7 @@ export function ParticipateForm({
                       max={new Date().getFullYear()}
                       step="1"
                       {...field}
+                      value={field.value ?? ""}
                     />
                   </FormControl>
                   <FormMessage />

--- a/src/components/klubturnier-anmeldung/roles-manager.tsx
+++ b/src/components/klubturnier-anmeldung/roles-manager.tsx
@@ -27,7 +27,12 @@ import { createSetupHelper, deleteSetupHelper } from "@/actions/setup-helper";
 import { createJuror, deleteJuror } from "@/actions/juror";
 import { sendRolesSelectionSummaryEmail } from "@/actions/email/roles";
 import { Profile } from "@/db/types/profile";
-import { DEFAULT_CLUB_KEY, DEFAULT_CLUB_LABEL } from "@/constants/constants";
+import {
+  CLUBLESS_KEY,
+  CLUBLESS_LABEL,
+  DEFAULT_CLUB_KEY,
+  DEFAULT_CLUB_LABEL,
+} from "@/constants/constants";
 import { createReferee, deleteReferee } from "@/actions/referee";
 import { Participant } from "@/db/types/participant";
 import type { PromotionEligibility } from "@/services/promotion";
@@ -247,21 +252,34 @@ export function RolesManager({
   );
 }
 
+function chessClubTypeForLabel(
+  chessClub: string,
+): z.infer<typeof participantFormSchema>["chessClubType"] {
+  if (chessClub === DEFAULT_CLUB_LABEL) {
+    return DEFAULT_CLUB_KEY;
+  }
+  if (chessClub === CLUBLESS_LABEL) {
+    return CLUBLESS_KEY;
+  }
+  return "other";
+}
+
 function buildParticipantInitialValues(
   current: RolesData["participant"],
   previous: Participant | null,
 ): z.infer<typeof participantFormSchema> | undefined {
   if (current) {
     return {
-      chessClubType:
-        current.chessClub === DEFAULT_CLUB_LABEL ? DEFAULT_CLUB_KEY : "other",
+      chessClubType: chessClubTypeForLabel(current.chessClub),
       chessClub: current.chessClub,
       title: current.title ?? "noTitle",
+      gender: current.gender ?? undefined,
       nationality: current.nationality ?? undefined,
       dwzRating: current.dwzRating ?? undefined,
       fideRating: current.fideRating ?? undefined,
       fideId: current.fideId ?? undefined,
       birthYear: current.birthYear ?? undefined,
+      birthDate: current.birthDate ?? undefined,
       preferredMatchDay: current.preferredMatchDay,
       secondaryMatchDays: current.secondaryMatchDays,
       notAvailableDays: current.notAvailableDays ?? [],
@@ -271,13 +289,14 @@ function buildParticipantInitialValues(
 
   if (previous) {
     return {
-      chessClubType:
-        previous.chessClub === DEFAULT_CLUB_LABEL ? DEFAULT_CLUB_KEY : "other",
+      chessClubType: chessClubTypeForLabel(previous.chessClub),
       chessClub: previous.chessClub,
       title: previous.title ?? "noTitle",
+      gender: previous.gender ?? undefined,
       nationality: previous.nationality ?? undefined,
       fideId: previous.fideId ?? undefined,
       birthYear: previous.birthYear ?? undefined,
+      birthDate: previous.birthDate ?? undefined,
       preferredMatchDay: previous.preferredMatchDay,
       secondaryMatchDays: previous.secondaryMatchDays,
       zpsClub: previous.zpsClubId ?? undefined,

--- a/src/components/sidebar/app-sidebar-wrapper.tsx
+++ b/src/components/sidebar/app-sidebar-wrapper.tsx
@@ -2,6 +2,7 @@ import { getAllTournaments } from "@/db/repositories/tournament";
 import { getRolesByUserId } from "@/db/repositories/role";
 import { auth } from "@/auth/utils";
 import { AppSidebar } from "./app-sidebar";
+import { getTournamentDocumentAvailability } from "@/actions/document";
 
 export async function AppSidebarWrapper() {
   const session = await auth();
@@ -10,11 +11,19 @@ export async function AppSidebarWrapper() {
     getAllTournaments(),
   ]);
 
+  const activeTournament = tournaments.find(
+    (t) => t.stage === "registration" || t.stage === "running",
+  );
+  const documentAvailability = activeTournament
+    ? await getTournamentDocumentAvailability(activeTournament.slug)
+    : { ausschreibung: false, turnierordnung: false };
+
   return (
     <AppSidebar
       session={session}
       tournaments={tournaments}
       userRoles={userRoles}
+      documentAvailability={documentAvailability}
     />
   );
 }

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -37,6 +37,8 @@ import { TournamentStage } from "@/db/types/tournament";
 import { Role } from "@/db/types/role";
 import { tournamentPath } from "@/lib/navigation";
 import { useTournamentSlug } from "@/hooks/use-tournament-slug";
+import { useEffect, useState } from "react";
+import { getTournamentDocumentAvailability } from "@/actions/document";
 
 type TournamentItem = {
   id: number;
@@ -69,6 +71,27 @@ export function AppSidebar({ session, tournaments, userRoles }: Props) {
   const isRunning = stage === "running";
   const isActive = stage === "registration" || stage === "running";
   const isDone = stage === "done";
+
+  const documentSlug = selectedTournament?.slug;
+  const [documents, setDocuments] = useState({
+    ausschreibung: false,
+    turnierordnung: false,
+  });
+  useEffect(() => {
+    if (!isActive || !documentSlug) {
+      setDocuments({ ausschreibung: false, turnierordnung: false });
+      return;
+    }
+    let cancelled = false;
+    getTournamentDocumentAvailability(documentSlug).then((result) => {
+      if (!cancelled) {
+        setDocuments(result);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isActive, documentSlug]);
 
   const isAdmin = userRoles.includes("admin");
   const isParticipant = userRoles.includes("participant");
@@ -177,20 +200,24 @@ export function AppSidebar({ session, tournaments, userRoles }: Props) {
             <SidebarGroupLabel>Dokumente</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                <SidebarLink
-                  href={tournamentPath(slug, "/ausschreibung")}
-                  icon={BookTextIcon}
-                  target="_blank"
-                >
-                  Ausschreibung
-                </SidebarLink>
-                <SidebarLink
-                  href={tournamentPath(slug, "/turnierordnung")}
-                  icon={BookTextIcon}
-                  target="_blank"
-                >
-                  Turnierordnung
-                </SidebarLink>
+                {documents.ausschreibung ? (
+                  <SidebarLink
+                    href={tournamentPath(slug, "/ausschreibung")}
+                    icon={BookTextIcon}
+                    target="_blank"
+                  >
+                    Ausschreibung
+                  </SidebarLink>
+                ) : null}
+                {documents.turnierordnung ? (
+                  <SidebarLink
+                    href={tournamentPath(slug, "/turnierordnung")}
+                    icon={BookTextIcon}
+                    target="_blank"
+                  >
+                    Turnierordnung
+                  </SidebarLink>
+                ) : null}
                 <SidebarLink
                   href="/anleitung"
                   icon={BookTextIcon}

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -37,8 +37,6 @@ import { TournamentStage } from "@/db/types/tournament";
 import { Role } from "@/db/types/role";
 import { tournamentPath } from "@/lib/navigation";
 import { useTournamentSlug } from "@/hooks/use-tournament-slug";
-import { useEffect, useState } from "react";
-import { getTournamentDocumentAvailability } from "@/actions/document";
 
 type TournamentItem = {
   id: number;
@@ -51,9 +49,10 @@ type Props = {
   session: Session | null;
   tournaments: TournamentItem[];
   userRoles: Role[];
+  documentAvailability: { ausschreibung: boolean; turnierordnung: boolean };
 };
 
-export function AppSidebar({ session, tournaments, userRoles }: Props) {
+export function AppSidebar({ session, tournaments, userRoles, documentAvailability }: Props) {
   const { setOpenMobile, isMobile } = useSidebar();
 
   const handleMobileMenuClick = () => {
@@ -71,27 +70,6 @@ export function AppSidebar({ session, tournaments, userRoles }: Props) {
   const isRunning = stage === "running";
   const isActive = stage === "registration" || stage === "running";
   const isDone = stage === "done";
-
-  const documentSlug = selectedTournament?.slug;
-  const [documents, setDocuments] = useState({
-    ausschreibung: false,
-    turnierordnung: false,
-  });
-  useEffect(() => {
-    if (!isActive || !documentSlug) {
-      setDocuments({ ausschreibung: false, turnierordnung: false });
-      return;
-    }
-    let cancelled = false;
-    getTournamentDocumentAvailability(documentSlug).then((result) => {
-      if (!cancelled) {
-        setDocuments(result);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [isActive, documentSlug]);
 
   const isAdmin = userRoles.includes("admin");
   const isParticipant = userRoles.includes("participant");
@@ -200,7 +178,7 @@ export function AppSidebar({ session, tournaments, userRoles }: Props) {
             <SidebarGroupLabel>Dokumente</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {documents.ausschreibung ? (
+                {documentAvailability.ausschreibung ? (
                   <SidebarLink
                     href={tournamentPath(slug, "/ausschreibung")}
                     icon={BookTextIcon}
@@ -209,7 +187,7 @@ export function AppSidebar({ session, tournaments, userRoles }: Props) {
                     Ausschreibung
                   </SidebarLink>
                 ) : null}
-                {documents.turnierordnung ? (
+                {documentAvailability.turnierordnung ? (
                   <SidebarLink
                     href={tournamentPath(slug, "/turnierordnung")}
                     icon={BookTextIcon}

--- a/src/components/ui/country-dropdown.tsx
+++ b/src/components/ui/country-dropdown.tsx
@@ -18,9 +18,6 @@ import { ChevronDown, CheckIcon } from "lucide-react";
 import { CircleFlag } from "react-circle-flags";
 import { countries } from "country-data-list";
 
-// Die Default-CDN von react-circle-flags sendet keinen Cross-Origin-Resource-Policy-Header
-// und wird daher von COEP: require-corp (next.config.ts, für Stockfish/SharedArrayBuffer)
-// blockiert. jsdelivr liefert CORP: cross-origin und funktioniert unter COEP.
 const FLAG_CDN_URL = "https://cdn.jsdelivr.net/npm/circle-flags/flags/";
 
 export interface Country {

--- a/src/components/ui/country-dropdown.tsx
+++ b/src/components/ui/country-dropdown.tsx
@@ -18,6 +18,11 @@ import { ChevronDown, CheckIcon } from "lucide-react";
 import { CircleFlag } from "react-circle-flags";
 import { countries } from "country-data-list";
 
+// Die Default-CDN von react-circle-flags sendet keinen Cross-Origin-Resource-Policy-Header
+// und wird daher von COEP: require-corp (next.config.ts, für Stockfish/SharedArrayBuffer)
+// blockiert. jsdelivr liefert CORP: cross-origin und funktioniert unter COEP.
+const FLAG_CDN_URL = "https://cdn.jsdelivr.net/npm/circle-flags/flags/";
+
 export interface Country {
   alpha2: string;
   alpha3: string;
@@ -95,6 +100,7 @@ const CountryDropdownComponent = (
               <CircleFlag
                 countryCode={selectedCountry.alpha2.toLowerCase()}
                 height={20}
+                cdnUrl={FLAG_CDN_URL}
               />
             </div>
             <span className="overflow-hidden text-ellipsis whitespace-nowrap">
@@ -133,6 +139,7 @@ const CountryDropdownComponent = (
                         <CircleFlag
                           countryCode={option.alpha2.toLowerCase()}
                           height={20}
+                          cdnUrl={FLAG_CDN_URL}
                         />
                       </div>
                       <span className="overflow-hidden text-ellipsis whitespace-nowrap">

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -15,6 +15,9 @@ export const matchDaysShort: Record<DayOfWeek, string> = {
 export const DEFAULT_CLUB_KEY = "hsk";
 export const DEFAULT_CLUB_LABEL = "Hamburger Schachklub von 1830 e.V.";
 
+export const CLUBLESS_KEY = "vereinslos";
+export const CLUBLESS_LABEL = "Vereinslos";
+
 export const monthLabels = [
   "Januar",
   "Februar",

--- a/src/db/repositories/participant.ts
+++ b/src/db/repositories/participant.ts
@@ -145,6 +145,7 @@ export async function getParticipantsWithZpsIdsByTournamentId(
       id: true,
       zpsPlayerId: true,
       zpsClubId: true,
+      fideId: true,
     },
   });
 }

--- a/src/db/schema/participant.ts
+++ b/src/db/schema/participant.ts
@@ -27,6 +27,7 @@ export const participant = pgTable(
     dwzRating: integer("dwz_rating"),
     fideRating: integer("fide_rating"),
     birthYear: integer("birth_year"),
+    birthDate: date("birth_date", { mode: "date" }),
     fideId: text("fide_id"),
     zpsClubId: text("zps_club_id"),
     zpsPlayerId: text("zps_player_id"),

--- a/src/lib/dwz-report/player-section.ts
+++ b/src/lib/dwz-report/player-section.ts
@@ -44,8 +44,7 @@ export function generatePlayerSection(
         data: player.startingGroupPosition.toString(),
       },
       { id: "name", data: player.name },
-      // TODO(separater PR): exaktes participant.birthDate als YYYYMMDD ausgeben, wenn vorhanden;
-      // DWZ-Auswertung verlangt für neue/vereinslose Spieler das volle Geburtsdatum (DSB-TRF-Pflicht ab 07.06.2026).
+      // TODO(separater PR): exaktes participant.birthDate als YYYYMMDD ausgeben (DSB verlangt volles Datum für neue Spieler)
       { id: "birthYear", data: player.birthYear?.toString() ?? "" },
       { id: "club", data: player.club },
       { id: "fideId", data: player.fideId ?? "" },

--- a/src/lib/dwz-report/player-section.ts
+++ b/src/lib/dwz-report/player-section.ts
@@ -44,6 +44,8 @@ export function generatePlayerSection(
         data: player.startingGroupPosition.toString(),
       },
       { id: "name", data: player.name },
+      // TODO(separater PR): exaktes participant.birthDate als YYYYMMDD ausgeben, wenn vorhanden;
+      // DWZ-Auswertung verlangt für neue/vereinslose Spieler das volle Geburtsdatum (DSB-TRF-Pflicht ab 07.06.2026).
       { id: "birthYear", data: player.birthYear?.toString() ?? "" },
       { id: "club", data: player.club },
       { id: "fideId", data: player.fideId ?? "" },

--- a/src/lib/fide-report/utils.ts
+++ b/src/lib/fide-report/utils.ts
@@ -29,8 +29,6 @@ export function getStringRepresentationForValue(value: TableEntryKeyValue) {
       return data;
     })
     .with({ id: "birthYear" }, ({ data }) => {
-      // TODO(separater PR): exaktes participant.birthDate als YYYY/MM/DD ausgeben,
-      // wenn vorhanden (vereinslose/neue Spieler brauchen das volle Datum für die FIDE-Wertung).
       return `${data.year}/00/00`;
     })
     .with({ id: "currentPoints" }, ({ data }) => {

--- a/src/lib/fide-report/utils.ts
+++ b/src/lib/fide-report/utils.ts
@@ -29,6 +29,8 @@ export function getStringRepresentationForValue(value: TableEntryKeyValue) {
       return data;
     })
     .with({ id: "birthYear" }, ({ data }) => {
+      // TODO(separater PR): exaktes participant.birthDate als YYYY/MM/DD ausgeben,
+      // wenn vorhanden (vereinslose/neue Spieler brauchen das volle Datum für die FIDE-Wertung).
       return `${data.year}/00/00`;
     })
     .with({ id: "currentPoints" }, ({ data }) => {

--- a/src/lib/fide/profile.ts
+++ b/src/lib/fide/profile.ts
@@ -1,0 +1,77 @@
+const FIDE_TITLE_MAP: Record<string, string> = {
+  grandmaster: "GM",
+  "international master": "IM",
+  "fide master": "FM",
+  "candidate master": "CM",
+  "woman grandmaster": "WGM",
+  "woman international master": "WIM",
+  "woman fide master": "WFM",
+  "woman candidate master": "WCM",
+};
+
+export type FideProfile = {
+  name: string | null;
+  fideId: string;
+  fideRating: number | null;
+  birthYear: number | null;
+  gender: "m" | "f" | null;
+  title: string | null;
+};
+
+export async function getFideProfile(
+  fideId: string,
+): Promise<FideProfile | null> {
+  const id = fideId.trim();
+  if (!/^\d+$/.test(id)) {
+    return null;
+  }
+
+  let html: string;
+  try {
+    const response = await fetch(`https://ratings.fide.com/profile/${id}`);
+    if (!response.ok) {
+      return null;
+    }
+    html = await response.text();
+  } catch {
+    return null;
+  }
+
+  const std = matchRating(html, "standart");
+
+  const birthYearRaw = matchInfo(html, "byear");
+  const birthYear =
+    birthYearRaw && /^\d{4}$/.test(birthYearRaw) ? Number(birthYearRaw) : null;
+
+  const sex = matchInfo(html, "sex");
+  const gender = sex === "Male" ? "m" : sex === "Female" ? "f" : null;
+
+  const titleRaw = matchInfo(html, "title");
+  const title =
+    titleRaw && titleRaw !== "None"
+      ? (FIDE_TITLE_MAP[titleRaw.toLowerCase()] ?? null)
+      : null;
+
+  const name =
+    html.match(/<title>([^<]+?)\s*FIDE Profile<\/title>/i)?.[1]?.trim() ?? null;
+
+  return { name, fideId: id, fideRating: std, birthYear, gender, title };
+}
+
+function matchRating(html: string, cls: string): number | null {
+  const m = html.match(
+    new RegExp(`profile-${cls}\\b[\\s\\S]*?<p>\\s*(\\d{1,4})\\s*</p>`, "i"),
+  );
+  const value = m ? Number(m[1]) : NaN;
+  return Number.isFinite(value) && value >= 1000 ? value : null;
+}
+
+function matchInfo(html: string, cls: string): string | null {
+  const m = html.match(
+    new RegExp(
+      `profile-info-${cls}\\b[^>]*>\\s*(?:<p>)?\\s*([^<\\n]+?)\\s*</`,
+      "i",
+    ),
+  );
+  return m ? m[1].trim() : null;
+}

--- a/src/lib/fide/profile.ts
+++ b/src/lib/fide/profile.ts
@@ -37,6 +37,10 @@ export async function getFideProfile(
     return null;
   }
 
+  if (html.includes("No record found")) {
+    return null;
+  }
+
   const std = matchRating(html, "standart");
 
   const birthYearRaw = matchInfo(html, "byear");

--- a/src/schema/participant.ts
+++ b/src/schema/participant.ts
@@ -1,14 +1,15 @@
-import { DEFAULT_CLUB_KEY } from "@/constants/constants";
+import { CLUBLESS_KEY, DEFAULT_CLUB_KEY } from "@/constants/constants";
 import { availableMatchDays } from "@/db/schema/columns.helpers";
 import z from "zod";
 
 export const participantFormSchema = z
   .object({
-    chessClubType: z.enum([DEFAULT_CLUB_KEY, "other"], {
+    chessClubType: z.enum([DEFAULT_CLUB_KEY, "other", CLUBLESS_KEY], {
       errorMap: () => ({ message: "Schachverein ist erforderlich" }),
     }),
     chessClub: z.string().optional(),
     title: z.string().optional(),
+    gender: z.enum(["m", "f"]).optional(),
     dwzRating: z.coerce
       .number()
       .min(0, "DWZ-Punktzahl muss mindestens 0 sein")
@@ -30,6 +31,10 @@ export const participantFormSchema = z
         new Date().getFullYear(),
         "Geburtsjahr kann nicht in der Zukunft liegen",
       )
+      .optional(),
+    birthDate: z.coerce
+      .date()
+      .max(new Date(), "Geburtsdatum kann nicht in der Zukunft liegen")
       .optional(),
 
     // Will not be used in the form, but can be used in the backend
@@ -83,6 +88,9 @@ export const participantFormSchema = z
   .refine(
     (data) => {
       if (data.fideRating != null && data.fideRating > 0) {
+        if (data.birthDate != null) {
+          return true;
+        }
         return (
           !!data.birthYear &&
           data.birthYear >= 1900 &&
@@ -94,5 +102,17 @@ export const participantFormSchema = z
     {
       message: "Geburtsjahr ist erforderlich, wenn Elo angegeben ist",
       path: ["birthYear"],
+    },
+  )
+  .refine(
+    (data) => {
+      if (data.chessClubType === CLUBLESS_KEY) {
+        return data.birthDate != null;
+      }
+      return true;
+    },
+    {
+      message: "Geburtsdatum ist für vereinslose Spieler erforderlich",
+      path: ["birthDate"],
     },
   );

--- a/src/schema/participant.ts
+++ b/src/schema/participant.ts
@@ -115,4 +115,16 @@ export const participantFormSchema = z
       message: "Geburtsdatum ist für vereinslose Spieler erforderlich",
       path: ["birthDate"],
     },
+  )
+  .refine(
+    (data) => {
+      if (data.chessClubType === CLUBLESS_KEY) {
+        return data.gender != null;
+      }
+      return true;
+    },
+    {
+      message: "Geschlecht ist für vereinslose Spieler erforderlich",
+      path: ["gender"],
+    },
   );

--- a/src/schema/participant.ts
+++ b/src/schema/participant.ts
@@ -27,14 +27,17 @@ export const participantFormSchema = z
     birthYear: z.coerce
       .number()
       .min(1900, "Geburtsjahr muss mindestens 1900 sein")
-      .max(
-        new Date().getFullYear(),
+      .refine(
+        (y) => y <= new Date().getFullYear(),
         "Geburtsjahr kann nicht in der Zukunft liegen",
       )
       .optional(),
     birthDate: z.coerce
       .date()
-      .max(new Date(), "Geburtsdatum kann nicht in der Zukunft liegen")
+      .refine(
+        (d) => d <= new Date(),
+        "Geburtsdatum kann nicht in der Zukunft liegen",
+      )
       .optional(),
 
     // Will not be used in the form, but can be used in the backend


### PR DESCRIPTION
## Änderungen

**FIDE-Elo-Scrape**
FIDE-Rating wird direkt von `ratings.fide.com` gelesen. Anmeldeformular: FIDE-ID wird unabhängig von der Rating gesetzt (Spieler können eine ID ohne Rating haben). Massen-Rating-Update: neu entdeckte FIDE-IDs aus DEWIS werden persistiert.

**Vereinslose Spieler**
DSB-Pflichtfelder Geschlecht und Geburtsdatum für vereinslose Spieler im Anmeldeformular. Datumsgrenzwerte werden per `.refine()` zur Validierungszeit ausgewertet.

**Dokument-Sidebar**
Ausschreibung und Turnierordnung werden nur angezeigt, wenn das jeweilige PDF vorhanden ist. Abfrage server-seitig im RSC-Wrapper statt Client-seitig per `useEffect`. Caching per `"use cache"`-Direktive mit `unstable_cacheLife("hours")`; `experimental.dynamicIO` aktiviert.

**COEP**
Regex für den `Cross-Origin-Embedder-Policy`-Header auf exakte Routensegmente begrenzt. COEP-kompatible Länderflaggen-Icons im Anmeldeformular.