### PR TITLE
feat: Auto-Verteiler – Spieltage & gleichstarke Parallelgruppen

### DIFF
--- a/src/components/admin/groups/edit-groups-grid.tsx
+++ b/src/components/admin/groups/edit-groups-grid.tsx
@@ -5,13 +5,23 @@ import { GroupsGrid } from "./groups-grid";
 import { useEffect, useState, useTransition } from "react";
 import { GridGroup } from "./types";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
 import { saveGroups } from "@/actions/group";
 import { MatchEnteringHelperWithName } from "@/db/types/match-entering-helper";
 import { useHelperAssignments } from "@/hooks/useHelperAssignments";
 import { toast } from "sonner";
 import invariant from "tiny-invariant";
 import { isError } from "@/lib/actions";
-import { sortParticipantsByTwz } from "@/lib/twz";
+import { distributeParticipantsByTwzAndDay } from "@/lib/group-distribution";
 import { PromotionTargetsProvider } from "./promotion-targets-context";
 
 export function EditGroupsGrid({
@@ -52,6 +62,16 @@ export function EditGroupsGrid({
     const targetSize = Math.floor(participantsPerGroup);
     if (!Number.isFinite(targetSize) || targetSize <= 0) {
       toast.error("Ungültige Zielgröße für Gruppen");
+      return;
+    }
+
+    const hasGroupWithoutDay = gridGroups.some(
+      (g) => !g.isDeleted && g.dayOfWeek == null,
+    );
+    if (hasGroupWithoutDay) {
+      toast.error(
+        "Bitte für jede Gruppe einen Spieltag setzen, bevor automatisch verteilt wird.",
+      );
       return;
     }
 
@@ -190,10 +210,62 @@ export function EditGroupsGrid({
     });
   };
 
+  const handleResetAssignments = () => {
+    const movedBack = gridGroups
+      .filter((g) => !g.isDeleted)
+      .flatMap((g) => g.participants);
+    const resetGroups = gridGroups.map((g) =>
+      g.isDeleted ? g : { ...g, participants: [] },
+    );
+
+    setGridGroups(resetGroups);
+    setUnassignedParticipants((prev) => [...prev, ...movedBack]);
+
+    startTransition(async () => {
+      const result = await saveGroups(tournamentId, resetGroups);
+      if (isError(result)) {
+        toast.error(result.error);
+      } else {
+        toast.success(
+          `${movedBack.length} Spieler zurückgesetzt und gespeichert.`,
+        );
+      }
+    });
+  };
+
   return (
     <PromotionTargetsProvider value={promotionTargets}>
       <div className="flex flex-col gap-4">
         <div className="flex justify-end gap-4 items-center">
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="outline" disabled={isPending}>
+                Gruppen leeren
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Bist du sicher?</DialogTitle>
+                <DialogDescription>
+                  Alle Spieler werden aus ihren Gruppen entfernt und als nicht
+                  zugewiesen markiert. Die Änderung wird sofort gespeichert.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button variant="outline">Abbrechen</Button>
+                </DialogClose>
+                <DialogClose asChild>
+                  <Button
+                    variant="destructive"
+                    onClick={handleResetAssignments}
+                  >
+                    Zurücksetzen
+                  </Button>
+                </DialogClose>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
           <Button
             variant="outline"
             onClick={handleAddNewGroup}
@@ -253,54 +325,28 @@ function distributeParticipants({
   unassigned: ParticipantWithName[];
   participantsPerGroup: number;
 }) {
-  const updatedGroups: GridGroup[] = [];
-  const assigned: ParticipantWithName[] = [];
+  const { assignmentsByGroupId, newUnassigned } =
+    distributeParticipantsByTwzAndDay({
+      groups: groups
+        .filter((g) => !g.isDeleted)
+        .map((g) => ({
+          id: g.id,
+          groupNumber: g.groupNumber,
+          tier: g.tier,
+          dayOfWeek: g.dayOfWeek,
+          participants: g.participants,
+        })),
+      unassigned,
+      participantsPerGroup,
+    });
 
-  const remainingIds = new Set(unassigned.map((p) => p.id));
+  const assignedParticipants: ParticipantWithName[] = [];
+  const updatedGroups = groups.map((group) => {
+    const toAdd = assignmentsByGroupId.get(group.id);
+    if (!toAdd || toAdd.length === 0) return group;
+    assignedParticipants.push(...toAdd);
+    return { ...group, participants: [...group.participants, ...toAdd] };
+  });
 
-  const twzOrdered = sortParticipantsByTwz(unassigned);
-
-  function takeFromOrdered(
-    source: ParticipantWithName[],
-    n: number,
-  ): ParticipantWithName[] {
-    if (n <= 0 || remainingIds.size === 0) return [];
-    const picked: ParticipantWithName[] = [];
-    for (const p of source) {
-      if (!remainingIds.has(p.id)) continue;
-      picked.push(p);
-      remainingIds.delete(p.id);
-      if (picked.length === n) break;
-    }
-    return picked;
-  }
-
-  for (const group of groups) {
-    if (group.isDeleted) {
-      updatedGroups.push(group);
-      continue;
-    }
-
-    const currentParticipantsCount = group.participants.length;
-    const participantsNeeded = participantsPerGroup - currentParticipantsCount;
-    if (participantsNeeded <= 0) {
-      updatedGroups.push(group);
-      continue;
-    }
-
-    const toAdd = takeFromOrdered(twzOrdered, participantsNeeded);
-    if (toAdd.length > 0) {
-      assigned.push(...toAdd);
-      updatedGroups.push({
-        ...group,
-        participants: [...group.participants, ...toAdd],
-      });
-    } else {
-      updatedGroups.push(group);
-    }
-  }
-
-  const newUnassigned = unassigned.filter((p) => remainingIds.has(p.id));
-
-  return { updatedGroups, newUnassigned, assignedParticipants: assigned };
+  return { updatedGroups, newUnassigned, assignedParticipants };
 }

--- a/src/components/admin/groups/group-stats.tsx
+++ b/src/components/admin/groups/group-stats.tsx
@@ -1,22 +1,17 @@
 import { useMemo } from "react";
 import { GridGroup } from "./types";
 import { CircleSlash2, Users } from "lucide-react";
-import { getTwz } from "@/lib/twz";
+import { averageTwz } from "@/lib/twz";
 
 type Props = {
   group: GridGroup;
 };
 
 export function GroupStats({ group }: Props) {
-  const averageTwz = useMemo(() => {
-    const twzValues = group.participants
-      .map((participant) => getTwz(participant))
-      .filter((twz): twz is number => twz !== null);
-    if (twzValues.length === 0) return 0;
-
-    const twzSum = twzValues.reduce((sum, twz) => sum + twz, 0);
-    return twzSum / twzValues.length;
-  }, [group.participants]);
+  const avgTwz = useMemo(
+    () => averageTwz(group.participants) ?? 0,
+    [group.participants],
+  );
 
   const averageElo = useMemo(() => {
     const participantsWithElo = group.participants.filter(
@@ -52,7 +47,7 @@ export function GroupStats({ group }: Props) {
       </div>
       <div className="flex items-center gap-1">
         <CircleSlash2 className="h-3 w-3" />
-        <span>TWZ: {Math.round(averageTwz)}</span>
+        <span>TWZ: {Math.round(avgTwz)}</span>
       </div>
       <div className="flex items-center gap-1">
         <CircleSlash2 className="h-3 w-3" />

--- a/src/lib/__tests__/group-distribution.test.ts
+++ b/src/lib/__tests__/group-distribution.test.ts
@@ -1,0 +1,293 @@
+import { describe, test, expect } from "vitest";
+import {
+  distributeParticipantsByTwzAndDay,
+  type DistributableGroup,
+} from "../group-distribution";
+import type { ParticipantWithName } from "@/db/types/participant";
+import type { DayOfWeek } from "@/db/types/group";
+
+function makeParticipant(
+  fideRating: number | null,
+  dwzRating: number | null,
+  lastName: string,
+  preferredMatchDay: DayOfWeek,
+  secondaryMatchDays: DayOfWeek[] = [],
+): ParticipantWithName {
+  return {
+    fideRating,
+    dwzRating,
+    preferredMatchDay,
+    secondaryMatchDays,
+    profile: { firstName: "Test", lastName },
+  } as ParticipantWithName;
+}
+
+function makeGroup(
+  id: number,
+  groupNumber: number,
+  tier: number | null,
+  dayOfWeek: DayOfWeek | null,
+  participants: ParticipantWithName[] = [],
+): DistributableGroup {
+  return { id, groupNumber, tier, dayOfWeek, participants };
+}
+
+function assignedNames(
+  result: ReturnType<typeof distributeParticipantsByTwzAndDay>,
+  groupId: number,
+): string[] {
+  return (result.assignmentsByGroupId.get(groupId) ?? []).map(
+    (p) => p.profile.lastName,
+  );
+}
+
+function unassignedNames(
+  result: ReturnType<typeof distributeParticipantsByTwzAndDay>,
+): string[] {
+  return result.newUnassigned.map((p) => p.profile.lastName);
+}
+
+describe("distributeParticipantsByTwzAndDay", () => {
+  test("empty input", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [],
+      unassigned: [],
+      participantsPerGroup: 4,
+    });
+    expect(result.assignmentsByGroupId.size).toBe(0);
+    expect(result.newUnassigned).toEqual([]);
+  });
+
+  test("no unassigned -> groups untouched", () => {
+    const seeded = makeParticipant(2000, null, "Seed", "tuesday");
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 0, "tuesday", [seeded])],
+      unassigned: [],
+      participantsPerGroup: 4,
+    });
+    expect(result.assignmentsByGroupId.size).toBe(0);
+    expect(result.newUnassigned).toEqual([]);
+  });
+
+  test("fills strongest-first and respects capacity", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 0, "tuesday")],
+      unassigned: [
+        makeParticipant(1400, null, "D", "tuesday"),
+        makeParticipant(2000, null, "A", "tuesday"),
+        makeParticipant(1600, null, "C", "tuesday"),
+        makeParticipant(1800, null, "B", "tuesday"),
+      ],
+      participantsPerGroup: 3,
+    });
+    expect(assignedNames(result, 1)).toEqual(["A", "B", "C"]);
+    expect(unassignedNames(result)).toEqual(["D"]);
+  });
+
+  test("day is a hard constraint -> unplaceable stays unassigned", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 0, "tuesday")],
+      unassigned: [makeParticipant(2000, null, "Solo", "thursday")],
+      participantsPerGroup: 3,
+    });
+    expect(result.assignmentsByGroupId.size).toBe(0);
+    expect(unassignedNames(result)).toEqual(["Solo"]);
+  });
+
+  test("cascade: strong player without A-day drops to a lower class; weaker fills A", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 0, "friday"), makeGroup(2, 2, 1, "tuesday")],
+      unassigned: [
+        makeParticipant(2200, null, "Strong", "tuesday"),
+        makeParticipant(1500, null, "Weak", "friday"),
+      ],
+      participantsPerGroup: 2,
+    });
+    expect(assignedNames(result, 2)).toEqual(["Strong"]);
+    expect(assignedNames(result, 1)).toEqual(["Weak"]);
+  });
+
+  test("strongest class fills before the next class", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 0, "tuesday"), makeGroup(2, 2, 1, "tuesday")],
+      unassigned: [
+        makeParticipant(2000, null, "P1", "tuesday"),
+        makeParticipant(1900, null, "P2", "tuesday"),
+        makeParticipant(1800, null, "P3", "tuesday"),
+        makeParticipant(1700, null, "P4", "tuesday"),
+        makeParticipant(1600, null, "P5", "tuesday"),
+      ],
+      participantsPerGroup: 4,
+    });
+    expect(assignedNames(result, 1)).toEqual(["P1", "P2", "P3", "P4"]);
+    expect(assignedNames(result, 2)).toEqual(["P5"]);
+  });
+
+  test("parallel groups stay balanced in size and strength", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 1, "tuesday"), makeGroup(2, 2, 1, "tuesday")],
+      unassigned: [
+        makeParticipant(1900, null, "a", "tuesday"),
+        makeParticipant(1850, null, "b", "tuesday"),
+        makeParticipant(1800, null, "c", "tuesday"),
+        makeParticipant(1750, null, "d", "tuesday"),
+      ],
+      participantsPerGroup: 4,
+    });
+    expect(assignedNames(result, 1)).toEqual(["a", "d"]);
+    expect(assignedNames(result, 2)).toEqual(["b", "c"]);
+  });
+
+  test("balance: fewest members first (pre-seeded group is deprioritized)", () => {
+    const seededB1 = [
+      makeParticipant(1900, null, "s1", "tuesday"),
+      makeParticipant(1850, null, "s2", "tuesday"),
+    ];
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [
+        makeGroup(1, 1, 1, "tuesday", seededB1),
+        makeGroup(2, 2, 1, "tuesday"),
+      ],
+      unassigned: [makeParticipant(1700, null, "new", "tuesday")],
+      participantsPerGroup: 4,
+    });
+    expect(assignedNames(result, 2)).toEqual(["new"]);
+    expect(result.assignmentsByGroupId.has(1)).toBe(false);
+  });
+
+  test("balance tie-break by lowest average TWZ", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [
+        makeGroup(1, 1, 1, "tuesday", [
+          makeParticipant(1900, null, "s1", "tuesday"),
+        ]),
+        makeGroup(2, 2, 1, "tuesday", [
+          makeParticipant(1500, null, "s2", "tuesday"),
+        ]),
+      ],
+      unassigned: [makeParticipant(1700, null, "new", "tuesday")],
+      participantsPerGroup: 4,
+    });
+    expect(assignedNames(result, 2)).toEqual(["new"]);
+  });
+
+  test("unrated member counts as lowest average -> that group filled first", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [
+        makeGroup(1, 1, 1, "tuesday", [
+          makeParticipant(1500, null, "rated", "tuesday"),
+        ]),
+        makeGroup(2, 2, 1, "tuesday", [
+          makeParticipant(null, null, "unrated", "tuesday"),
+        ]),
+      ],
+      unassigned: [makeParticipant(1700, null, "new", "tuesday")],
+      participantsPerGroup: 4,
+    });
+    expect(assignedNames(result, 2)).toEqual(["new"]);
+  });
+
+  test("unrated players are placed last into remaining compatible slots", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 0, "tuesday")],
+      unassigned: [
+        makeParticipant(null, null, "Unrated", "tuesday"),
+        makeParticipant(1800, null, "Rated", "tuesday"),
+      ],
+      participantsPerGroup: 2,
+    });
+    expect(assignedNames(result, 1)).toEqual(["Rated", "Unrated"]);
+  });
+
+  test("class beats preferred day (precedence)", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 0, "thursday"), makeGroup(2, 2, 1, "tuesday")],
+      unassigned: [makeParticipant(1800, null, "P", "tuesday", ["thursday"])],
+      participantsPerGroup: 4,
+    });
+    expect(assignedNames(result, 1)).toEqual(["P"]);
+  });
+
+  test("preferred day beats secondary day within the same class", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 1, "tuesday"), makeGroup(2, 2, 1, "thursday")],
+      unassigned: [makeParticipant(1800, null, "P", "tuesday", ["thursday"])],
+      participantsPerGroup: 4,
+    });
+    expect(assignedNames(result, 1)).toEqual(["P"]);
+  });
+
+  test("null-day (wildcard) is the lowest day bucket", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 1, "thursday"), makeGroup(2, 2, 1, null)],
+      unassigned: [makeParticipant(1800, null, "P", "tuesday", ["thursday"])],
+      participantsPerGroup: 4,
+    });
+    expect(assignedNames(result, 1)).toEqual(["P"]);
+  });
+
+  test("null tier is treated as the weakest class", () => {
+    const full = distributeParticipantsByTwzAndDay({
+      groups: [
+        makeGroup(1, 1, 1, "tuesday", [
+          makeParticipant(1800, null, "x", "tuesday"),
+          makeParticipant(1700, null, "y", "tuesday"),
+        ]),
+        makeGroup(2, 2, null, "tuesday"),
+      ],
+      unassigned: [makeParticipant(1600, null, "P", "tuesday")],
+      participantsPerGroup: 2,
+    });
+    expect(assignedNames(full, 2)).toEqual(["P"]);
+
+    const open = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 1, "tuesday"), makeGroup(2, 2, null, "tuesday")],
+      unassigned: [makeParticipant(1600, null, "P", "tuesday")],
+      participantsPerGroup: 2,
+    });
+    expect(assignedNames(open, 1)).toEqual(["P"]);
+  });
+
+  test("groupNumber is the final tie-break", () => {
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(10, 3, 1, "tuesday"), makeGroup(11, 2, 1, "tuesday")],
+      unassigned: [makeParticipant(1800, null, "P", "tuesday")],
+      participantsPerGroup: 4,
+    });
+    expect(assignedNames(result, 11)).toEqual(["P"]);
+  });
+
+  test("invariant: every player is either assigned exactly once or unassigned", () => {
+    const players = [
+      makeParticipant(2000, null, "A", "tuesday"),
+      makeParticipant(1800, null, "B", "friday"),
+      makeParticipant(1600, null, "C", "tuesday", ["friday"]),
+      makeParticipant(null, null, "D", "thursday"),
+    ];
+    const result = distributeParticipantsByTwzAndDay({
+      groups: [makeGroup(1, 1, 0, "tuesday"), makeGroup(2, 2, 1, "friday")],
+      unassigned: players,
+      participantsPerGroup: 2,
+    });
+    const assigned = [...result.assignmentsByGroupId.values()].flat();
+    const all = [...assigned, ...result.newUnassigned];
+    expect(all).toHaveLength(players.length);
+    expect(new Set(all.map((p) => p.profile.lastName)).size).toBe(
+      players.length,
+    );
+  });
+
+  test("does not mutate the input groups or participants array", () => {
+    const groupParticipants = [makeParticipant(1900, null, "seed", "tuesday")];
+    const groups = [makeGroup(1, 1, 1, "tuesday", groupParticipants)];
+    const unassigned = [makeParticipant(1700, null, "new", "tuesday")];
+    distributeParticipantsByTwzAndDay({
+      groups,
+      unassigned,
+      participantsPerGroup: 4,
+    });
+    expect(groupParticipants).toHaveLength(1);
+    expect(groups[0].participants).toBe(groupParticipants);
+    expect(unassigned).toHaveLength(1);
+  });
+});

--- a/src/lib/group-distribution.ts
+++ b/src/lib/group-distribution.ts
@@ -1,0 +1,122 @@
+import { DayOfWeek } from "@/db/types/group";
+import { ParticipantWithName } from "@/db/types/participant";
+import { averageTwz, sortParticipantsByTwz } from "@/lib/twz";
+
+export type DistributableGroup = {
+  id: number;
+  groupNumber: number;
+  tier: number | null;
+  dayOfWeek: DayOfWeek | null;
+  participants: ParticipantWithName[];
+};
+
+type WorkingGroup = {
+  group: DistributableGroup;
+  members: ParticipantWithName[];
+  added: ParticipantWithName[];
+  remaining: number;
+  tierKey: number;
+};
+
+function availableDays(participant: ParticipantWithName): Set<DayOfWeek> {
+  return new Set<DayOfWeek>([
+    participant.preferredMatchDay,
+    ...participant.secondaryMatchDays,
+  ]);
+}
+
+/**
+ * Wählt unter gleichwertigen Gruppen: wenigste Mitglieder → niedrigster
+ * TWZ-Schnitt (Gruppe ohne bewertete Mitglieder zuerst) → kleinste groupNumber.
+ */
+function pickByBalance(groups: WorkingGroup[]): WorkingGroup {
+  return groups.reduce((best, candidate) => {
+    if (candidate.members.length !== best.members.length) {
+      return candidate.members.length < best.members.length ? candidate : best;
+    }
+    const candidateAvg = averageTwz(candidate.members) ?? -Infinity;
+    const bestAvg = averageTwz(best.members) ?? -Infinity;
+    if (candidateAvg !== bestAvg) {
+      return candidateAvg < bestAvg ? candidate : best;
+    }
+    return candidate.group.groupNumber < best.group.groupNumber
+      ? candidate
+      : best;
+  });
+}
+
+/**
+ * Verteilt unverteilte Teilnehmer auf die Gruppen (Turnierordnung 2026 §4.1):
+ * Tag = harte Bedingung, stärkstmögliche Klasse (Tier) zuerst, innerhalb der
+ * Klasse bevorzugter Tag vor sekundären, dann Balance (Größe, dann TWZ-Schnitt).
+ * Reine Funktion – mutiert die Eingaben nicht.
+ */
+export function distributeParticipantsByTwzAndDay({
+  groups,
+  unassigned,
+  participantsPerGroup,
+}: {
+  groups: DistributableGroup[];
+  unassigned: ParticipantWithName[];
+  participantsPerGroup: number;
+}): {
+  assignmentsByGroupId: Map<number, ParticipantWithName[]>;
+  newUnassigned: ParticipantWithName[];
+} {
+  const working: WorkingGroup[] = groups.map((group) => ({
+    group,
+    members: [...group.participants],
+    added: [],
+    remaining: Math.max(0, participantsPerGroup - group.participants.length),
+    tierKey: group.tier ?? Number.POSITIVE_INFINITY,
+  }));
+
+  const newUnassigned: ParticipantWithName[] = [];
+
+  for (const player of sortParticipantsByTwz(unassigned)) {
+    const days = availableDays(player);
+
+    const candidates = working.filter(
+      (w) =>
+        w.remaining > 0 &&
+        (w.group.dayOfWeek === null || days.has(w.group.dayOfWeek)),
+    );
+    if (candidates.length === 0) {
+      newUnassigned.push(player);
+      continue;
+    }
+
+    const targetTier = Math.min(...candidates.map((w) => w.tierKey));
+    const tierCands = candidates.filter((w) => w.tierKey === targetTier);
+
+    const preferred = tierCands.filter(
+      (w) => w.group.dayOfWeek === player.preferredMatchDay,
+    );
+    const secondary = tierCands.filter(
+      (w) =>
+        w.group.dayOfWeek !== null &&
+        w.group.dayOfWeek !== player.preferredMatchDay &&
+        days.has(w.group.dayOfWeek),
+    );
+    const wildcard = tierCands.filter((w) => w.group.dayOfWeek === null);
+    const bucket = preferred.length
+      ? preferred
+      : secondary.length
+        ? secondary
+        : wildcard;
+
+    const chosen = pickByBalance(bucket);
+    chosen.members.push(player);
+    chosen.added.push(player);
+    chosen.remaining -= 1;
+  }
+
+  const assignmentsByGroupId = new Map<number, ParticipantWithName[]>();
+  for (const w of working) {
+    if (w.added.length > 0) {
+      assignmentsByGroupId.set(w.group.id, w.added);
+    }
+  }
+
+  return { assignmentsByGroupId, newUnassigned };
+}

--- a/src/lib/twz.ts
+++ b/src/lib/twz.ts
@@ -29,6 +29,18 @@ export function formatTwz(participant: RatingFields, fallback = "-"): string {
 }
 
 /**
+ * Durchschnittliche TWZ der bewerteten Teilnehmer. Gibt null zurück, wenn kein
+ * Teilnehmer eine Wertung hat (Aufrufer wählt den passenden Platzhalter).
+ */
+export function averageTwz(participants: RatingFields[]): number | null {
+  const ratings = participants
+    .map((participant) => getTwz(participant))
+    .filter((twz): twz is number => twz !== null);
+  if (ratings.length === 0) return null;
+  return ratings.reduce((sum, twz) => sum + twz, 0) / ratings.length;
+}
+
+/**
  * Sortiert Teilnehmer absteigend nach TWZ. Tie-Break bei gleicher TWZ:
  * 1. zweite (niedrigere) Wertung absteigend (Spieler mit nur einer Wertung zuletzt),
  * 2. Nachname alphabetisch.


### PR DESCRIPTION
## Änderungen

**Tag-bewusste Gruppenverteilung**
Der Auto-Verteiler (`distributeParticipantsByTwzAndDay`, `src/lib/group-distribution.ts`) berücksichtigt jetzt die Spieltage. Der Spieltag einer Gruppe ist eine harte Bedingung – ein Spieler kommt nur in eine Gruppe, deren Tag er spielen kann (bevorzugter Tag vor sekundären). Die Klassenzuordnung ist tag-getrieben: stärkstmögliche Klasse mit freiem, tag-kompatiblem Platz, sonst eine Klasse tiefer, sonst unverteilt. Spieler ohne Wertung werden zuletzt einsortiert.

**Gleichstarke Parallelgruppen**
Innerhalb einer Klasse werden Parallelgruppen ausgeglichen: zuerst nach Gruppengröße, dann nach TWZ-Schnitt. Reine, getestete Funktion (~18 Vitest-Fälle). `averageTwz` wurde als geteilte Helferfunktion nach `src/lib/twz.ts` extrahiert und in `group-stats` wiederverwendet (DRY).

**Spieltag-Guard**
Vor dem automatischen Verteilen müssen alle Gruppen einen Spieltag gesetzt haben; sonst bricht der Verteiler mit Fehler-Toast ab, damit die Verteilung garantiert tag-bewusst arbeitet.

**Gruppen leeren**
Neuer Button im Gruppen-Editor (mit Bestätigungsdialog „Bist du sicher?") setzt alle zugewiesenen Spieler zurück in den Nicht-zugewiesen-Bereich und speichert direkt – für eine saubere Neuverteilung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
