### PR TITLE
chore: Bezeichnung "Rangliste" zu "Tabelle" umbenennen

### DIFF
--- a/src/app/(main)/turniere/[slug]/rangliste/page.tsx
+++ b/src/app/(main)/turniere/[slug]/rangliste/page.tsx
@@ -34,7 +34,7 @@ export default async function Page({
           <Card>
             <CardHeader>
               <CardTitle className="text-2xl font-bold tracking-tight">
-                Rangliste
+                Tabelle
               </CardTitle>
             </CardHeader>
             <div className="p-6">
@@ -62,9 +62,9 @@ export default async function Page({
   return (
     <div>
       <div className="md:w-2/3 mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-4">Rangliste</h1>
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Tabelle</h1>
         <p className="text-gray-700">
-          Ohne Rundenauswahl wird die Gesamtrangliste über alle Runden
+          Ohne Rundenauswahl wird die Gesamttabelle über alle Runden
           angezeigt. Zur Feinwertung wird das Sonneborn-Berger-System verwendet.
         </p>
       </div>

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -122,7 +122,7 @@ export function AppSidebar({ session, tournaments, userRoles, documentAvailabili
                 href={tournamentPath(slug, "/rangliste")}
                 icon={Medal}
               >
-                Rangliste
+                Tabelle
               </SidebarLink>
               {!isDone && (
                 <SidebarLink

--- a/src/email/templates/tournament-started/participant-content.tsx
+++ b/src/email/templates/tournament-started/participant-content.tsx
@@ -46,7 +46,7 @@ export function ParticipantContent({ slug, participantGroup }: Props) {
         </a>
       </p>
       <p>
-        Die Rangliste deiner Gruppe findest du unter folgendem Link:
+        Die Tabelle deiner Gruppe findest du unter folgendem Link:
         <br />{" "}
         <a
           href={`https://klubturnier.hsk1830.de${standingsUrl}`}


### PR DESCRIPTION
## Was

Die sichtbare UI-Bezeichnung **"Rangliste"** wurde zu **"Tabelle"** umbenannt.

Betroffene Stellen:
- Seitentitel der Tabellen-Seite (`CardTitle` + `h1`)
- Fließtext: "Gesamtrangliste" → "Gesamttabelle"
- Sidebar-Link
- E-Mail-Text (Turnierstart, Teilnehmer)

## Bewusst unverändert

Im Code bleibt es bei **standings** (englischer Begriff). Ebenfalls unangetastet:
- Route `/rangliste`
- Variable `ranglisteUrl`
- `StandingsDisplay` / `standings*`-Identifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)