### PR TITLE
Datums-Pipeline: Kalendertage als zonenfreie Strings, TZ-Bug behoben, date-fns entfernt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,17 @@ bun add <package>
 
 ## Next.js version
 Project is on **15.1.9**. `experimental.dynamicIO` and `"use cache"` are not available — they require canary / Next.js 16. Use `unstable_cache` from `next/cache` for caching.
+
+## Dates & time — two worlds, never mix
+All helpers live in `src/lib/date.ts` (Luxon). The tournament is a physical event in Hamburg, so `Europe/Berlin` is the event timezone.
+
+**Calendar days** (matchday.date, birthDate, notAvailableDays, tournament start/end/registration dates) are zoneless `'YYYY-MM-DD'` strings end-to-end — drizzle `date({ mode: "string" })`, never a JS `Date`:
+- parse to Luxon: `parseDateOnly(s)` · display: `formatDateOnly(s)` · today: `todayDateOnly()`
+- serialize a DateTime: `toDateOnly(dt)` · from a UTC picker date: `utcDateToDateOnly(d)`
+- equality/ranges: plain string comparison (`===`, `<`, `<=`)
+- react-day-picker: always bind with `timeZone="UTC"` + `TZDate`
+
+**Instants** (createdAt, game start, postponements) are UTC timestamps in the DB, displayed in Berlin:
+- `toLocalDateTime(date)` / `getCurrentLocalDateTime()`, format with `formatDate`, `formatLongDate`, `formatEventDateTime`, `formatShortDateOrHoliday`
+
+Naming: `parse*` = string in, `format*` = display out, `to*` = serialize. Never `new Date('YYYY-MM-DD')`, never `toISOString()` on browser-local dates, never date-fns (removed).

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "fischer",
@@ -40,7 +39,6 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "country-data-list": "^1.4.1",
-        "date-fns": "^4.1.0",
         "date-holidays": "^3.24.4",
         "drizzle-orm": "^0.44.7",
         "drizzle-seed": "^0.3.1",

--- a/drizzle/0025_fix_date_only_tz_shift.sql
+++ b/drizzle/0025_fix_date_only_tz_shift.sql
@@ -1,0 +1,18 @@
+-- Custom SQL migration file, put your code below! --
+
+-- Data migration: correct the historical -1 day timezone shift on participant date-only columns.
+-- Rows were written from browser-local-midnight JS Dates which drizzle serialised via
+-- toISOString() (UTC), storing the previous calendar day. Shift every affected value +1 day.
+-- matchday.date and tournament.*_date are NOT affected (written from day-time context /
+-- date strings) and must not be touched.
+
+UPDATE "participant"
+SET "not_available_days" = (
+  SELECT array_agg("d" + 1 ORDER BY "d")
+  FROM unnest("not_available_days") AS "d"
+)
+WHERE cardinality("not_available_days") > 0;
+--> statement-breakpoint
+UPDATE "participant"
+SET "birth_date" = "birth_date" + 1
+WHERE "birth_date" IS NOT NULL;

--- a/drizzle/0025_fix_date_only_tz_shift.sql
+++ b/drizzle/0025_fix_date_only_tz_shift.sql
@@ -8,7 +8,7 @@
 
 UPDATE "participant"
 SET "not_available_days" = (
-  SELECT array_agg("d" + 1 ORDER BY "d")
+  SELECT array_agg(DISTINCT "d" + 1)
   FROM unnest("not_available_days") AS "d"
 )
 WHERE cardinality("not_available_days") > 0;

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,1898 @@
+{
+  "id": "2d43a21b-6a39-4c32-a150-830ff93d69a5",
+  "prevId": "adcdbf6d-e481-4da0-a34f-5bc77a8db0e8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "game_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "white_player_id": {
+          "name": "white_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "black_player_id": {
+          "name": "black_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pgn_id": {
+          "name": "pgn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_number": {
+          "name": "board_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_postponement": {
+      "name": "game_postponement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "game_postponement_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponing_participant_id": {
+          "name": "postponing_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponed_by_profile_id": {
+          "name": "postponed_by_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group": {
+      "name": "group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "name": "group_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_tournament_id_group_number_pk": {
+          "name": "group_tournament_id_group_number_pk",
+          "columns": [
+            "tournament_id",
+            "group_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.juror": {
+      "name": "juror",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "juror_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "juror_tournament_id_profile_id_unique": {
+          "name": "juror_tournament_id_profile_id_unique",
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_match_entering_helper": {
+      "name": "group_match_entering_helper",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_entering_helper_id": {
+          "name": "match_entering_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_match_entering_helper_group_id_match_entering_helper_id_pk": {
+          "name": "group_match_entering_helper_group_id_match_entering_helper_id_pk",
+          "columns": [
+            "group_id",
+            "match_entering_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_entering_helper": {
+      "name": "match_entering_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "match_entering_helper_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_groups_to_enter": {
+          "name": "number_of_groups_to_enter",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_entering_helper_tournament_id_profile_id_unique": {
+          "name": "match_entering_helper_tournament_id_profile_id_unique",
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday": {
+      "name": "matchday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "matchday_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_week_id": {
+          "name": "tournament_week_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_needed": {
+          "name": "referee_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_game": {
+      "name": "matchday_game",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_game_matchday_id_game_id_pk": {
+          "name": "matchday_game_matchday_id_game_id_pk",
+          "columns": [
+            "matchday_id",
+            "game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_referee": {
+      "name": "matchday_referee",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_id": {
+          "name": "referee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_referee_matchday_id_referee_id_pk": {
+          "name": "matchday_referee_matchday_id_referee_id_pk",
+          "columns": [
+            "matchday_id",
+            "referee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_setup_helper": {
+      "name": "matchday_setup_helper",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_helper_id": {
+          "name": "setup_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_setup_helper_matchday_id_setup_helper_id_pk": {
+          "name": "matchday_setup_helper_matchday_id_setup_helper_id_pk",
+          "columns": [
+            "matchday_id",
+            "setup_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant": {
+      "name": "participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "participant_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chess_club": {
+          "name": "chess_club",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'m'"
+        },
+        "dwz_rating": {
+          "name": "dwz_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_rating": {
+          "name": "fide_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_club_id": {
+          "name": "zps_club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_player_id": {
+          "name": "zps_player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_days": {
+          "name": "secondary_match_days",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "not_available_days": {
+          "name": "not_available_days",
+          "type": "date[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_fee_payed": {
+          "name": "entry_fee_payed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exercise_promotion_right": {
+          "name": "exercise_promotion_right",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participant_tournament_id_profile_id_unique": {
+          "name": "participant_tournament_id_profile_id_unique",
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_group": {
+      "name": "participant_group",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_position": {
+          "name": "group_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "participant_group_group_id_participant_id_group_position_pk": {
+          "name": "participant_group_group_id_participant_id_group_position_pk",
+          "columns": [
+            "group_id",
+            "participant_id",
+            "group_position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pgn": {
+      "name": "pgn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pgn_game_id_unique": {
+          "name": "pgn_game_id_unique",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "pgn_game_id_game_id_fk": {
+          "name": "pgn_game_id_game_id_fk",
+          "tableFrom": "pgn",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "tableTo": "game",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "profile_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_title": {
+          "name": "academic_title",
+          "type": "academic_title",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_email_unique": {
+          "name": "profile_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referee": {
+      "name": "referee",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "referee_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "referee_tournament_id_profile_id_unique": {
+          "name": "referee_tournament_id_profile_id_unique",
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_helper": {
+      "name": "setup_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "setup_helper_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "setup_helper_tournament_id_profile_id_unique": {
+          "name": "setup_helper_tournament_id_profile_id_unique",
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament": {
+      "name": "tournament",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "tournament_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_rounds": {
+          "name": "number_of_rounds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_registration_date": {
+          "name": "end_registration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_announcement_offset_days": {
+          "name": "group_announcement_offset_days",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_limit": {
+          "name": "time_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_clocks_digital": {
+          "name": "all_clocks_digital",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tie_break_method": {
+          "name": "tie_break_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "software": {
+          "name": "software",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "tournament_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registration'"
+        },
+        "game_start_time": {
+          "name": "game_start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'19:00:00'"
+        },
+        "organizer_profile_id": {
+          "name": "organizer_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "one_tournament_in_registration": {
+          "name": "one_tournament_in_registration",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"tournament\".\"stage\" = 'registration'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_slug_unique": {
+          "name": "tournament_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_week": {
+      "name": "tournament_week",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "tournament_week_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_week_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "week_number": {
+          "name": "week_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainer": {
+      "name": "trainer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "trainer_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trainer_tournament_id_profile_id_unique": {
+          "name": "trainer_tournament_id_profile_id_unique",
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.academic_title": {
+      "name": "academic_title",
+      "schema": "public",
+      "values": [
+        "Dr."
+      ]
+    },
+    "public.result": {
+      "name": "result",
+      "schema": "public",
+      "values": [
+        "1:0",
+        "0:1",
+        "½-½",
+        "+:-",
+        "-:+",
+        "-:-",
+        "0-½",
+        "½-0"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "m",
+        "f"
+      ]
+    },
+    "public.match_day": {
+      "name": "match_day",
+      "schema": "public",
+      "values": [
+        "tuesday",
+        "thursday",
+        "friday"
+      ]
+    },
+    "public.tournament_stage": {
+      "name": "tournament_stage",
+      "schema": "public",
+      "values": [
+        "registration",
+        "running",
+        "done"
+      ]
+    },
+    "public.tournament_week_status": {
+      "name": "tournament_week_status",
+      "schema": "public",
+      "values": [
+        "regular",
+        "catch-up"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1782669876082,
       "tag": "0024_large_medusa",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1783015072822,
+      "tag": "0025_fix_date_only_tz_shift",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "country-data-list": "^1.4.1",
-    "date-fns": "^4.1.0",
     "date-holidays": "^3.24.4",
     "drizzle-orm": "^0.44.7",
     "drizzle-seed": "^0.3.1",

--- a/src/actions/email/appointment.ts
+++ b/src/actions/email/appointment.ts
@@ -8,7 +8,7 @@ import {
   sendSetupHelperAppointmentNotification,
   sendRefereeAppointmentNotification,
 } from "@/email/appointment";
-import { displayLongDate, toLocalDateTime } from "@/lib/date";
+import { formatLongDate, parseDateOnly } from "@/lib/date";
 import { eq } from "drizzle-orm";
 import invariant from "tiny-invariant";
 
@@ -31,7 +31,7 @@ export async function sendSetupHelperAppointmentEmail(
 
   const profile = setupHelperData.profile;
   const setupHelperName = `${profile.firstName} ${profile.lastName}`;
-  const formattedDate = displayLongDate(toLocalDateTime(matchdayInfo.date));
+  const formattedDate = formatLongDate(parseDateOnly(matchdayInfo.date));
 
   const emailData = {
     name: setupHelperName,
@@ -63,7 +63,7 @@ export async function sendRefereeAppointmentEmail(
 
   const profile = refereeData.profile;
   const refereeName = `${profile.firstName} ${profile.lastName}`;
-  const formattedDate = displayLongDate(toLocalDateTime(matchdayInfo.date));
+  const formattedDate = formatLongDate(parseDateOnly(matchdayInfo.date));
 
   const emailData = {
     name: refereeName,

--- a/src/actions/email/game-postponement.ts
+++ b/src/actions/email/game-postponement.ts
@@ -3,7 +3,7 @@
 import { db } from "@/db/client";
 import { group } from "@/db/schema/group";
 import { sendGamePostponementNotifications } from "@/email/gamePostponement";
-import { displayLongDate, toLocalDateTime } from "@/lib/date";
+import { formatLongDate, parseDateOnly } from "@/lib/date";
 import { eq } from "drizzle-orm";
 import type { GameWithParticipantProfilesAndMatchday } from "@/db/types/game";
 import type { ParticipantWithName } from "@/db/types/participant";
@@ -27,10 +27,10 @@ export async function sendGamePostponementEmails(
   const whitePlayerName = `${gameData.whiteParticipant.profile.firstName} ${gameData.whiteParticipant.profile.lastName}`;
   const blackPlayerName = `${gameData.blackParticipant.profile.firstName} ${gameData.blackParticipant.profile.lastName}`;
 
-  const oldDateFormatted = displayLongDate(
-    toLocalDateTime(currentMatchday.date),
+  const oldDateFormatted = formatLongDate(
+    parseDateOnly(currentMatchday.date),
   );
-  const newDateFormatted = displayLongDate(toLocalDateTime(newMatchday.date));
+  const newDateFormatted = formatLongDate(parseDateOnly(newMatchday.date));
 
   const whitePlayerEmailData = {
     playerEmail: gameData.whiteParticipant.profile.email,

--- a/src/actions/fide-report.ts
+++ b/src/actions/fide-report.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/fide-report/format-fide-name";
 import { PlayerEntry, Result } from "@/lib/fide-report/types";
 import { calculateStandings } from "@/lib/standings";
+import { parseDateOnly, toDateOnly, toLocalDateTime } from "@/lib/date";
 import { DateTime } from "luxon";
 import invariant from "tiny-invariant";
 import { match } from "ts-pattern";
@@ -81,10 +82,12 @@ export const generateFideReportFile = action(
 
       const isWhiteParticipantDisabled =
         whiteParticipant.participant.deletedAt != null &&
-        whiteParticipant.participant.deletedAt <= date;
+        toDateOnly(toLocalDateTime(whiteParticipant.participant.deletedAt)) <
+          date;
       const isBlackParticipantDisabled =
         blackParticipant.participant.deletedAt != null &&
-        blackParticipant.participant.deletedAt <= date;
+        toDateOnly(toLocalDateTime(blackParticipant.participant.deletedAt)) <
+          date;
 
       return !isWhiteParticipantDisabled && !isBlackParticipantDisabled;
     });
@@ -211,7 +214,7 @@ export const generateFideReportFile = action(
               const isWhite = whiteGameIds.includes(game.id);
 
               return {
-                scheduled: DateTime.fromJSDate(game.matchday.date),
+                scheduled: parseDateOnly(game.matchday.date),
                 opponentGroupPosition: getInitialGroupPositionOfPlayer(
                   isWhite ? game.blackParticipantId! : game.whiteParticipantId!,
                 ),
@@ -254,8 +257,8 @@ export const generateFideReportFile = action(
         tournamentName,
         location,
         federation,
-        startDate: DateTime.fromJSDate(startDate),
-        endDate: DateTime.fromJSDate(endDate),
+        startDate: parseDateOnly(startDate),
+        endDate: parseDateOnly(endDate),
         numberOfPlayers,
         numberOfRatedPlayers,
         tournamentType,

--- a/src/actions/participant.ts
+++ b/src/actions/participant.ts
@@ -19,6 +19,7 @@ import {
 } from "@/constants/constants";
 import { revalidatePath } from "next/cache";
 import { action } from "@/lib/actions";
+import { parseDateOnly } from "@/lib/date";
 import { getFideProfile } from "@/lib/fide/profile";
 
 function parseRating(value: string | undefined): number | null {
@@ -50,7 +51,7 @@ export async function createParticipant(
 
   const entryFeePayed = data.chessClubType === DEFAULT_CLUB_KEY ? null : false;
   const birthYear = data.birthDate
-    ? Number(data.birthDate.slice(0, 4))
+    ? parseDateOnly(data.birthDate).year
     : data.birthYear;
 
   const tournament = await getTournamentById(tournamentId);

--- a/src/actions/participant.ts
+++ b/src/actions/participant.ts
@@ -50,7 +50,7 @@ export async function createParticipant(
 
   const entryFeePayed = data.chessClubType === DEFAULT_CLUB_KEY ? null : false;
   const birthYear = data.birthDate
-    ? data.birthDate.getFullYear()
+    ? Number(data.birthDate.slice(0, 4))
     : data.birthYear;
 
   const tournament = await getTournamentById(tournamentId);

--- a/src/actions/pgn.ts
+++ b/src/actions/pgn.ts
@@ -11,7 +11,7 @@ import { getTournamentById } from "@/db/repositories/tournament";
 import { getGroupById } from "@/db/repositories/group";
 import { getMatchdayById } from "@/db/repositories/match-day";
 import { getParticipantsByGroupId } from "@/db/repositories/participant";
-import { toLocalDateTime, toDateString } from "@/lib/date";
+import { formatDateOnly } from "@/lib/date";
 import { getFullName } from "@/lib/participant";
 import { SearchParamsNumbers } from "@/components/partien/mass-pgn-download-button";
 
@@ -61,10 +61,7 @@ export const buildPgnFileName = action(
     if (matchdayId) {
       const matchday = await getMatchdayById(matchdayId);
       if (matchday) {
-        const dateStr = toDateString(toLocalDateTime(matchday.date)).replace(
-          /\./g,
-          "_",
-        );
+        const dateStr = formatDateOnly(matchday.date).replace(/\./g, "_");
         parts.push(dateStr);
       }
     }

--- a/src/actions/tournament.ts
+++ b/src/actions/tournament.ts
@@ -12,7 +12,7 @@ import { and, eq, ne } from "drizzle-orm";
 import { TournamentStage } from "@/db/types/tournament";
 import { matchday } from "@/db/schema/matchday";
 import { isHoliday } from "@/lib/holidays";
-import { getCurrentLocalDateTime } from "@/lib/date";
+import { getCurrentLocalDateTime, toDateOnly } from "@/lib/date";
 import {
   getActiveTournament,
   getOpenRegistrationTournament,
@@ -46,9 +46,9 @@ export async function createTournament(
       slug: data.slug,
       allClocksDigital: true,
       club: data.clubName,
-      startDate: new Date(data.startDate),
-      endDate: new Date(data.endDate),
-      endRegistrationDate: new Date(data.endRegistrationDate),
+      startDate: data.startDate,
+      endDate: data.endDate,
+      endRegistrationDate: data.endRegistrationDate,
       groupAnnouncementOffsetDays: data.groupAnnouncementOffsetDays,
       email: data.email,
       location: data.location,
@@ -112,9 +112,9 @@ export async function updateTournament(
     name: data.name,
     slug: data.slug,
     club: data.clubName,
-    startDate: new Date(data.startDate),
-    endDate: new Date(data.endDate),
-    endRegistrationDate: new Date(data.endRegistrationDate),
+    startDate: data.startDate,
+    endDate: data.endDate,
+    endRegistrationDate: data.endRegistrationDate,
     groupAnnouncementOffsetDays: data.groupAnnouncementOffsetDays,
     email: data.email,
     location: data.location,
@@ -196,65 +196,44 @@ function getMatchDays(
   >["selectedCalendarWeeks"],
 ) {
   return insertedTournamentWeeks.flatMap((week, index) => {
-    const tuesday = getCurrentLocalDateTime()
-      .set({
-        weekNumber: week.weekNumber,
-        weekday: 2,
-      })
-      .toJSDate();
-    const thursday = getCurrentLocalDateTime()
-      .set({
-        weekNumber: week.weekNumber,
-        weekday: 4,
-      })
-      .toJSDate();
-    const friday = getCurrentLocalDateTime()
-      .set({
-        weekNumber: week.weekNumber,
-        weekday: 5,
-      })
-      .toJSDate();
+    const tuesday = getCurrentLocalDateTime().set({
+      weekNumber: week.weekNumber,
+      weekday: 2,
+    });
+    const thursday = getCurrentLocalDateTime().set({
+      weekNumber: week.weekNumber,
+      weekday: 4,
+    });
+    const friday = getCurrentLocalDateTime().set({
+      weekNumber: week.weekNumber,
+      weekday: 5,
+    });
 
     const matchDays: (typeof matchday.$inferInsert)[] = [];
-    if (!isHoliday(tuesday)) {
+    if (!isHoliday(tuesday.toJSDate())) {
       matchDays.push({
         tournamentId,
         tournamentWeekId: week.id,
         dayOfWeek: "tuesday",
-        date: getCurrentLocalDateTime()
-          .set({
-            weekNumber: week.weekNumber,
-            weekday: 2,
-          })
-          .toJSDate(),
+        date: toDateOnly(tuesday),
         refereeNeeded: selectedCalendarWeeks[index].tuesday.refereeNeeded,
       });
     }
-    if (!isHoliday(thursday)) {
+    if (!isHoliday(thursday.toJSDate())) {
       matchDays.push({
         tournamentId,
         tournamentWeekId: week.id,
         dayOfWeek: "thursday",
-        date: getCurrentLocalDateTime()
-          .set({
-            weekNumber: week.weekNumber,
-            weekday: 4,
-          })
-          .toJSDate(),
+        date: toDateOnly(thursday),
         refereeNeeded: selectedCalendarWeeks[index].thursday.refereeNeeded,
       });
     }
-    if (!isHoliday(friday)) {
+    if (!isHoliday(friday.toJSDate())) {
       matchDays.push({
         tournamentId,
         tournamentWeekId: week.id,
         dayOfWeek: "friday",
-        date: getCurrentLocalDateTime()
-          .set({
-            weekNumber: week.weekNumber,
-            weekday: 5,
-          })
-          .toJSDate(),
+        date: toDateOnly(friday),
         refereeNeeded: selectedCalendarWeeks[index].friday.refereeNeeded,
       });
     }

--- a/src/app/(full-page)/turniere/[slug]/partien/drucken/page.tsx
+++ b/src/app/(full-page)/turniere/[slug]/partien/drucken/page.tsx
@@ -2,7 +2,7 @@ import { PrintButton } from "@/components/partien/print/print-button";
 import { Badge } from "@/components/ui/badge";
 import { getGamesByTournamentId } from "@/db/repositories/game";
 import { getTournamentBySlug } from "@/db/repositories/tournament";
-import { toDateString } from "@/lib/date";
+import { formatDate } from "@/lib/date";
 import { getDateTimeFromTournamentTime } from "@/lib/game-time";
 import { getParticipantFullName } from "@/lib/participant";
 import { notFound } from "next/navigation";
@@ -67,7 +67,7 @@ export default async function Page({
                 <Badge variant="outline">{index + 1}</Badge>
               </div>
               <div className="basis-[8rem] text-center">
-                {toDateString(game.gameDateTime)}
+                {formatDate(game.gameDateTime)}
               </div>
               <div className="basis-16 text-center">
                 <Badge variant="secondary">{game.group.groupName}</Badge>

--- a/src/app/(setup)/klubturnier-anmeldung/page.tsx
+++ b/src/app/(setup)/klubturnier-anmeldung/page.tsx
@@ -1,5 +1,15 @@
+import {
+  getFideRatingById,
+  getParticipantEloData,
+} from "@/actions/participant";
 import { authWithRedirect } from "@/auth/utils";
-import { RolesManager } from "@/components/klubturnier-anmeldung/roles-manager";
+import {
+  ParticipantEloPrefill,
+  RolesManager,
+} from "@/components/klubturnier-anmeldung/roles-manager";
+import { DEFAULT_CLUB_LABEL } from "@/constants/constants";
+import { Participant } from "@/db/types/participant";
+import { Profile } from "@/db/types/profile";
 import { getProfileByUserId } from "@/db/repositories/profile";
 import { getRolesDataByProfileIdAndTournamentId } from "@/db/repositories/role";
 import {
@@ -9,6 +19,38 @@ import {
 import { getParticipantByProfileIdAndTournamentId } from "@/db/repositories/participant";
 import { getPromotionEligibility } from "@/services/promotion";
 import { redirect } from "next/navigation";
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
+  return Promise.race([
+    promise,
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
+  ]);
+}
+
+async function getPrefillEloData(
+  profile: Profile,
+  previousParticipant: Participant,
+): Promise<ParticipantEloPrefill | null> {
+  try {
+    const eloData = await withTimeout(
+      getParticipantEloData(profile.firstName, profile.lastName),
+      5000,
+    );
+    if (eloData) {
+      return eloData;
+    }
+    if (previousParticipant.fideId) {
+      const fideRating = await withTimeout(
+        getFideRatingById(previousParticipant.fideId),
+        5000,
+      );
+      if (fideRating != null) {
+        return { fideRating };
+      }
+    }
+  } catch {}
+  return null;
+}
 
 export default async function RolesPage() {
   const session = await authWithRedirect();
@@ -48,6 +90,13 @@ export default async function RolesPage() {
       )
     : null;
 
+  const prefillEloData =
+    initialValues.participant == null &&
+    previousParticipant != null &&
+    previousParticipant.chessClub === DEFAULT_CLUB_LABEL
+      ? await getPrefillEloData(profile, previousParticipant)
+      : null;
+
   return (
     <div className="space-y-8">
       <header className="text-center">
@@ -67,6 +116,7 @@ export default async function RolesPage() {
         profile={profile}
         promotionEligibility={promotionEligibility}
         previousParticipant={previousParticipant ?? null}
+        prefillEloData={prefillEloData}
       />
     </div>
   );

--- a/src/components/admin/matchday/matchday-assignment-form.tsx
+++ b/src/components/admin/matchday/matchday-assignment-form.tsx
@@ -11,7 +11,7 @@ import { MatchDayWithRefereeAndSetupHelpers } from "@/db/types/match-day";
 import { SetupHelperWithName } from "@/db/types/setup-helper";
 import { SetupHelperSelector } from "./setup-helper-selector";
 import { DateTime } from "luxon";
-import { displayShortDateOrHoliday } from "@/lib/date";
+import { formatShortDateOrHoliday } from "@/lib/date";
 import { generateRefereeAssignmentSchedule } from "@/lib/tournament-schedule";
 import {
   Table,
@@ -147,7 +147,7 @@ export function MatchdayAssignmentForm({
   );
 
   const displayDateWithStyling = (date: DateTime) => {
-    const dateText = displayShortDateOrHoliday(date);
+    const dateText = formatShortDateOrHoliday(date);
     if (dateText === "Feiertag") {
       return <span className="text-red-500 italic">Feiertag</span>;
     }

--- a/src/components/admin/pairings/pairing.tsx
+++ b/src/components/admin/pairings/pairing.tsx
@@ -5,8 +5,7 @@ import { GameWithMatchday } from "@/db/types/game";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ParticipantEntry } from "../groups/participant-entry";
 import { Bird } from "lucide-react";
-import { isSameDate, toDateString, toLocalDateTime } from "@/lib/date";
-import { DateTime } from "luxon";
+import { formatDateOnly } from "@/lib/date";
 
 export function Pairing({ group }: { group: GroupWithParticipantsAndGames }) {
   if (!group.games || group.games.length === 0) {
@@ -32,7 +31,7 @@ export function Pairing({ group }: { group: GroupWithParticipantsAndGames }) {
     matchdayDate,
   }: {
     participantId: number;
-    matchdayDate: DateTime;
+    matchdayDate: string;
   }) => {
     const participant = findParticipant(participantId);
 
@@ -48,13 +47,7 @@ export function Pairing({ group }: { group: GroupWithParticipantsAndGames }) {
     }
 
     const isNotAvailable =
-      participant.notAvailableDays?.some((notAvailableDate) => {
-        // TODO: HOTFIX: Add 1 day to compensate for timezone offset in existing database data
-        const adjustedDate = toLocalDateTime(notAvailableDate).plus({
-          days: 1,
-        });
-        return isSameDate(adjustedDate, matchdayDate);
-      }) || false;
+      participant.notAvailableDays?.includes(matchdayDate) || false;
 
     return (
       <div
@@ -110,8 +103,8 @@ export function Pairing({ group }: { group: GroupWithParticipantsAndGames }) {
         {rounds.map((round) => {
           const games = gamesByRound.get(round) || [];
 
-          const gameDate = toLocalDateTime(games[0].matchdayGame.matchday.date);
-          const dateDisplay = toDateString(gameDate);
+          const matchdayDate = games[0].matchdayGame.matchday.date;
+          const dateDisplay = formatDateOnly(matchdayDate);
 
           return (
             <TabsContent key={round} value={`round-${round}`} className="mt-0">
@@ -143,13 +136,13 @@ export function Pairing({ group }: { group: GroupWithParticipantsAndGames }) {
                         <div>
                           <ParticipantCell
                             participantId={game.whiteParticipantId!}
-                            matchdayDate={gameDate}
+                            matchdayDate={matchdayDate}
                           />
                         </div>
                         <div>
                           <ParticipantCell
                             participantId={game.blackParticipantId!}
-                            matchdayDate={gameDate}
+                            matchdayDate={matchdayDate}
                           />
                         </div>
                       </div>

--- a/src/components/admin/participant-row.tsx
+++ b/src/components/admin/participant-row.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { ProfileWithName } from "@/db/types/profile";
 import { getParticipantFullName } from "@/lib/participant";
+import { formatDate, toLocalDateTime } from "@/lib/date";
 import { getTwz } from "@/lib/twz";
 
 type Props = {
@@ -169,9 +170,7 @@ export function ParticipantRow({
           {participant.profile.deletedAt && (
             <span className="text-xs text-red-600">
               Deaktiviert:{" "}
-              {new Date(participant.profile.deletedAt).toLocaleDateString(
-                "de-DE",
-              )}
+              {formatDate(toLocalDateTime(participant.profile.deletedAt))}
             </span>
           )}
         </div>

--- a/src/components/admin/tournament/edit-tournament-details.tsx
+++ b/src/components/admin/tournament/edit-tournament-details.tsx
@@ -77,15 +77,9 @@ export default function EditTournamentDetails({
       allClocksDigital: tournament?.allClocksDigital ?? true,
       phone: tournament?.phone ?? "040 20981411",
       email: tournament?.email ?? "klubturnier@hsk1830.de",
-      startDate: tournament?.startDate
-        ? tournament.startDate.toISOString().split("T")[0]
-        : "",
-      endDate: tournament?.endDate
-        ? tournament.endDate.toISOString().split("T")[0]
-        : "",
-      endRegistrationDate: tournament?.endRegistrationDate
-        ? tournament.endRegistrationDate.toISOString().split("T")[0]
-        : "",
+      startDate: tournament?.startDate ?? "",
+      endDate: tournament?.endDate ?? "",
+      endRegistrationDate: tournament?.endRegistrationDate ?? "",
       organizerProfileId: tournament?.organizerProfileId?.toString() ?? "",
       selectedCalendarWeeks,
     },

--- a/src/components/admin/user-row.tsx
+++ b/src/components/admin/user-row.tsx
@@ -28,6 +28,7 @@ import {
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { matchDaysShort } from "@/constants/constants";
+import { formatDate, toLocalDateTime } from "@/lib/date";
 import { ProfileWithName } from "@/db/types/profile";
 import { createTrainer, deleteTrainer } from "@/actions/trainer";
 
@@ -182,7 +183,7 @@ export function UserRow({
           {user.deletedAt && (
             <span className="text-xs text-red-600">
               Deaktiviert:{" "}
-              {new Date(user.deletedAt).toLocaleDateString("de-DE")}
+              {formatDate(toLocalDateTime(user.deletedAt))}
             </span>
           )}
         </div>

--- a/src/components/calendar/my-games-calendar.tsx
+++ b/src/components/calendar/my-games-calendar.tsx
@@ -18,7 +18,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useRouter } from "next/navigation";
 import { buildGameViewUrl, tournamentPath } from "@/lib/navigation";
 import { useTournamentSlug } from "@/hooks/use-tournament-slug";
-import { isSameDate, toLocalDateTime } from "@/lib/date";
+import { parseDateOnly, toDateOnly, toLocalDateTime } from "@/lib/date";
 
 type Props = {
   events: CalendarEvent[];
@@ -38,12 +38,12 @@ export function MyGamesCalendar({ events, matchdays = [] }: Props) {
     editable: event.extendedProps.eventType === "game",
   }));
 
-  const validDropDates = matchdays.map((matchday) =>
-    toLocalDateTime(matchday.date),
-  );
+  const validDropDates = matchdays.map((matchday) => matchday.date);
 
   const initialDate =
-    validDropDates.length > 0 ? validDropDates[0].toJSDate() : new Date();
+    validDropDates.length > 0
+      ? parseDateOnly(validDropDates[0]).toJSDate()
+      : new Date();
 
   const handleEventDrop = useCallback(
     async (info: EventDropArg) => {
@@ -63,17 +63,15 @@ export function MyGamesCalendar({ events, matchdays = [] }: Props) {
         return;
       }
 
-      const newDate = toLocalDateTime(info.event.start!);
-      const isMatchdayDate = validDropDates.some((validDate) =>
-        isSameDate(validDate, newDate),
-      );
+      const newDate = toDateOnly(toLocalDateTime(info.event.start!));
+      const isMatchdayDate = validDropDates.includes(newDate);
       if (!isMatchdayDate) {
         info.revert();
         return;
       }
 
-      const targetMatchday = matchdays.find((matchday) =>
-        isSameDate(toLocalDateTime(matchday.date), newDate),
+      const targetMatchday = matchdays.find(
+        (matchday) => matchday.date === newDate,
       ) as MatchDay;
 
       startTransition(async () => {
@@ -135,20 +133,16 @@ export function MyGamesCalendar({ events, matchdays = [] }: Props) {
     (dropInfo) => {
       if (validDropDates.length === 0) return true;
 
-      const dropDate = toLocalDateTime(dropInfo.start);
-      return validDropDates.some((validDate) =>
-        isSameDate(validDate, dropDate),
-      );
+      const dropDate = toDateOnly(toLocalDateTime(dropInfo.start));
+      return validDropDates.includes(dropDate);
     },
     [validDropDates],
   );
 
   const handleDayCellDidMount = useCallback(
     (info: DayCellMountArg) => {
-      const cellDate = toLocalDateTime(info.date);
-      const isMatchdayDate = validDropDates.some((validDate) =>
-        isSameDate(validDate, cellDate),
-      );
+      const cellDate = toDateOnly(toLocalDateTime(info.date));
+      const isMatchdayDate = validDropDates.includes(cellDate);
 
       if (isMatchdayDate) {
         info.el.classList.add("drop-zone-valid");
@@ -173,10 +167,7 @@ export function MyGamesCalendar({ events, matchdays = [] }: Props) {
         const htmlElement = cell as HTMLElement;
         const dateStr = htmlElement.getAttribute("data-date");
         if (dateStr) {
-          const cellDate = toLocalDateTime(new Date(dateStr));
-          const isMatchdayDate = validDropDates.some((validDate) =>
-            isSameDate(validDate, cellDate),
-          );
+          const isMatchdayDate = validDropDates.includes(dateStr);
 
           if (isMatchdayDate) {
             htmlElement.classList.add("drop-zone-valid");
@@ -190,16 +181,12 @@ export function MyGamesCalendar({ events, matchdays = [] }: Props) {
 
   const handleDateClick = useCallback(
     (info: DateClickArg) => {
-      const clickedDate = toLocalDateTime(info.date);
-      const isMatchdayDate = validDropDates.some((validDate) =>
-        isSameDate(validDate, clickedDate),
-      );
+      const clickedDate = toDateOnly(toLocalDateTime(info.date));
+      const isMatchdayDate = validDropDates.includes(clickedDate);
 
       if (!isMatchdayDate) return;
 
-      const matchday = matchdays.find((md) =>
-        isSameDate(toLocalDateTime(md.date), clickedDate),
-      );
+      const matchday = matchdays.find((md) => md.date === clickedDate);
 
       if (matchday) {
         const url = buildGameViewUrl({

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { TZDate } from "react-day-picker";
 import { CalendarIcon } from "lucide-react";
@@ -66,7 +66,6 @@ type Props = {
   initialValues?: z.infer<typeof participantFormSchema>;
   canDelete: boolean;
   promotionEligibility: PromotionEligibility | null;
-  prefillFromPreviousParticipant: boolean;
   onSubmit: (data: z.infer<typeof participantFormSchema>) => Promise<void>;
   onDelete: () => Promise<void>;
   tournament: Tournament;
@@ -77,7 +76,6 @@ export function ParticipateForm({
   initialValues,
   canDelete,
   promotionEligibility,
-  prefillFromPreviousParticipant,
   onSubmit,
   onDelete,
   tournament,
@@ -177,15 +175,6 @@ export function ParticipateForm({
       }
     });
   };
-
-  useEffect(() => {
-    if (
-      prefillFromPreviousParticipant &&
-      initialValues?.chessClubType === DEFAULT_CLUB_KEY
-    ) {
-      fetchAndApplyEloData();
-    }
-  }, []);
 
   const handleChessClubTypeChange = (value: "hsk" | "other" | "vereinslos") => {
     form.setValue("chessClubType", value);

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
-import { format } from "date-fns";
+import { TZDate } from "react-day-picker";
 import { CalendarIcon } from "lucide-react";
 import z from "zod";
 import {
@@ -40,6 +40,12 @@ import { MatchDaysCheckboxes } from "./matchday-selection";
 import { CountryDropdown } from "@/components/ui/country-dropdown";
 import { cn } from "@/lib/utils";
 import { isHoliday } from "@/lib/holidays";
+import {
+  formatDateOnly,
+  parseDateOnly,
+  todayDateOnly,
+  utcDateToDateOnly,
+} from "@/lib/date";
 import { Tournament } from "@/db/types/tournament";
 import {
   getFideRatingById,
@@ -368,16 +374,10 @@ export function ParticipateForm({
                     <FormControl>
                       <Input
                         type="date"
-                        max={format(new Date(), "yyyy-MM-dd")}
-                        value={
-                          field.value ? format(field.value, "yyyy-MM-dd") : ""
-                        }
+                        max={todayDateOnly()}
+                        value={field.value ?? ""}
                         onChange={(e) =>
-                          field.onChange(
-                            e.target.value
-                              ? new Date(`${e.target.value}T00:00:00`)
-                              : undefined,
-                          )
+                          field.onChange(e.target.value || undefined)
                         }
                       />
                     </FormControl>
@@ -637,14 +637,21 @@ export function ParticipateForm({
                 <PopoverContent className="w-auto p-0" align="start">
                   <Calendar
                     mode="multiple"
-                    selected={field.value ?? []}
-                    onSelect={(selectedDates) => {
-                      if (selectedDates && selectedDates.length <= 5) {
-                        field.onChange(selectedDates);
+                    timeZone="UTC"
+                    selected={(field.value ?? []).map(
+                      (day) => new TZDate(day, "UTC"),
+                    )}
+                    onSelect={(dates) => {
+                      const days = (dates ?? []).map(utcDateToDateOnly);
+                      if (days.length <= 5) {
+                        field.onChange(days);
                       }
                     }}
                     numberOfMonths={1}
-                    disabled={handleDateDisabled}
+                    disabled={(date) =>
+                      !(field.value ?? []).includes(utcDateToDateOnly(date)) &&
+                      handleDateDisabled(date)
+                    }
                   />
                 </PopoverContent>
               </Popover>
@@ -663,12 +670,12 @@ export function ParticipateForm({
                     Ausgewählte Tage ({field.value.length}):
                   </p>
                   <div className="flex flex-wrap gap-1">
-                    {field.value.map((date, index) => (
+                    {field.value.map((day, index) => (
                       <span
                         key={index}
                         className="inline-flex items-center px-2 py-1 rounded-md bg-secondary text-secondary-foreground text-xs"
                       >
-                        {format(date, "dd.MM.yyyy")}
+                        {formatDateOnly(day)}
                       </span>
                     ))}
                   </div>
@@ -734,31 +741,16 @@ export function ParticipateForm({
   );
 }
 
-function isDateDisabled(date: Date, min: Date, max: Date) {
-  const dateOnly = new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate(),
-  );
-  const startDateOnly = new Date(
-    min.getFullYear(),
-    min.getMonth(),
-    min.getDate(),
-  );
-  const endDateOnly = new Date(
-    max.getFullYear(),
-    max.getMonth(),
-    max.getDate(),
-  );
-
-  if (dateOnly < startDateOnly || dateOnly > endDateOnly) {
+function isDateDisabled(date: Date, min: string, max: string) {
+  const day = utcDateToDateOnly(date);
+  if (day < min || day > max) {
     return true;
   }
 
-  if (isHoliday(date)) {
+  const dt = parseDateOnly(day);
+  if (isHoliday(dt.toJSDate())) {
     return true;
   }
 
-  const dayOfWeek = date.getDay();
-  return dayOfWeek !== 2 && dayOfWeek !== 4 && dayOfWeek !== 5;
+  return ![2, 4, 5].includes(dt.weekday);
 }

--- a/src/components/klubturnier-anmeldung/roles-manager.tsx
+++ b/src/components/klubturnier-anmeldung/roles-manager.tsx
@@ -18,7 +18,11 @@ import { refereeFormSchema } from "@/schema/referee";
 import { matchEnteringHelperFormSchema } from "@/schema/matchEnteringHelper";
 import { setupHelperFormSchema } from "@/schema/setupHelper";
 import { useRouter } from "next/navigation";
-import { createParticipant, deleteParticipant } from "@/actions/participant";
+import {
+  createParticipant,
+  deleteParticipant,
+  getParticipantEloData,
+} from "@/actions/participant";
 import {
   createMatchEnteringHelper,
   deleteMatchEnteringHelper,
@@ -37,6 +41,10 @@ import { createReferee, deleteReferee } from "@/actions/referee";
 import { Participant } from "@/db/types/participant";
 import type { PromotionEligibility } from "@/services/promotion";
 
+export type ParticipantEloPrefill = Partial<
+  NonNullable<Awaited<ReturnType<typeof getParticipantEloData>>>
+>;
+
 type Props = {
   userId: string;
   rolesData: RolesData;
@@ -44,6 +52,7 @@ type Props = {
   profile: Profile;
   promotionEligibility: PromotionEligibility | null;
   previousParticipant: Participant | null;
+  prefillEloData: ParticipantEloPrefill | null;
 };
 
 export function RolesManager({
@@ -53,13 +62,13 @@ export function RolesManager({
   profile,
   promotionEligibility,
   previousParticipant,
+  prefillEloData,
 }: Props) {
   const participantInitialValues = buildParticipantInitialValues(
     rolesData.participant,
     previousParticipant,
+    prefillEloData,
   );
-  const prefillFromPreviousParticipant =
-    rolesData.participant == null && previousParticipant != null;
   const canDeleteParticipant = rolesData.participant != null;
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
@@ -166,7 +175,6 @@ export function RolesManager({
             initialValues={participantInitialValues}
             canDelete={canDeleteParticipant}
             promotionEligibility={promotionEligibility}
-            prefillFromPreviousParticipant={prefillFromPreviousParticipant}
             onSubmit={handleParticipateFormSubmit}
             onDelete={handleDeleteParticipant}
             tournament={tournament}
@@ -270,6 +278,7 @@ function chessClubTypeForLabel(
 function buildParticipantInitialValues(
   current: RolesData["participant"],
   previous: Participant | null,
+  prefill: ParticipantEloPrefill | null,
 ): z.infer<typeof participantFormSchema> | undefined {
   if (current) {
     return {
@@ -291,19 +300,24 @@ function buildParticipantInitialValues(
   }
 
   if (previous) {
+    const fideId = prefill?.fideId ?? previous.fideId ?? undefined;
+    const prefillNationality =
+      prefill?.nationality !== "?" ? prefill?.nationality : undefined;
     return {
       chessClubType: chessClubTypeForLabel(previous.chessClub),
       chessClub: previous.chessClub,
-      title: previous.title ?? "noTitle",
-      gender: previous.gender ?? undefined,
-      nationality: previous.nationality ?? undefined,
-      fideId: previous.fideId ?? undefined,
-      birthYear: previous.birthYear ?? undefined,
+      title: prefill?.title ?? previous.title ?? "noTitle",
+      gender: prefill?.gender ?? previous.gender ?? undefined,
+      nationality: prefillNationality ?? previous.nationality ?? undefined,
+      dwzRating: prefill?.dwzRating ?? undefined,
+      fideRating: prefill?.fideRating && fideId ? prefill.fideRating : undefined,
+      fideId,
+      birthYear: prefill?.birthYear ?? previous.birthYear ?? undefined,
       birthDate: previous.birthDate ?? undefined,
       preferredMatchDay: previous.preferredMatchDay,
       secondaryMatchDays: previous.secondaryMatchDays,
-      zpsClub: previous.zpsClubId ?? undefined,
-      zpsPlayer: previous.zpsPlayerId ?? undefined,
+      zpsClub: prefill?.zpsClub ?? previous.zpsClubId ?? undefined,
+      zpsPlayer: prefill?.zpsPlayer ?? previous.zpsPlayerId ?? undefined,
       notAvailableDays: [],
       exercisePromotionRight: false,
     };

--- a/src/components/notification/pending-result-item.tsx
+++ b/src/components/notification/pending-result-item.tsx
@@ -4,7 +4,7 @@ import { ParticipatingPlayerDisplay } from "./participating-player-display";
 import { getGameWithParticipantsAndMatchday } from "@/db/repositories/game";
 import { getTournamentById } from "@/db/repositories/tournament";
 import invariant from "tiny-invariant";
-import { toDateString, toLocalDateTime } from "@/lib/date";
+import { formatDateOnly } from "@/lib/date";
 
 type Props = {
   gameId: number;
@@ -56,8 +56,7 @@ export async function PendingResultItem({
             </span>
           </h4>
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            Gespielt am{" "}
-            {toDateString(toLocalDateTime(game.matchdayGame.matchday.date))}
+            Gespielt am {formatDateOnly(game.matchdayGame.matchday.date)}
           </p>
         </div>
       </div>

--- a/src/components/partien/games-list.tsx
+++ b/src/components/partien/games-list.tsx
@@ -21,12 +21,7 @@ import { MatchDay } from "@/db/types/match-day";
 import { authClient } from "@/auth-client";
 import { Role } from "@/db/types/role";
 import { GameActions } from "./game-actions";
-import {
-  getCurrentLocalDateTime,
-  toDateString,
-  toLocalDateTime,
-  isSameDate,
-} from "@/lib/date";
+import { formatDateOnly, parseDateOnly, todayDateOnly } from "@/lib/date";
 import { getParticipantFullName } from "@/lib/participant";
 import { getTwz } from "@/lib/twz";
 
@@ -75,12 +70,7 @@ export function GamesList({
 
       const game = games.find((g) => g.id === gameId);
       const isGameInPastOrToday = game
-        ? toLocalDateTime(game.matchdayGame.matchday.date) <
-            getCurrentLocalDateTime() ||
-          isSameDate(
-            toLocalDateTime(game.matchdayGame.matchday.date),
-            getCurrentLocalDateTime(),
-          )
+        ? game.matchdayGame.matchday.date <= todayDateOnly()
         : false;
 
       return {
@@ -181,9 +171,7 @@ export function GamesList({
                   )}
                 </TableCell>
                 <TableCell className="w-24 text-center">
-                  {toDateString(
-                    toLocalDateTime(game.matchdayGame.matchday.date),
-                  )}
+                  {formatDateOnly(game.matchdayGame.matchday.date)}
                 </TableCell>
                 {hasAnyActions && (
                   <TableCell className="flex items-center gap-2">
@@ -192,7 +180,7 @@ export function GamesList({
                       currentResult={game.result}
                       onResultChange={onResultChange}
                       availableMatchdays={availableMatchdays}
-                      currentGameDate={toLocalDateTime(
+                      currentGameDate={parseDateOnly(
                         game.matchdayGame.matchday.date,
                       )}
                       game={game}
@@ -232,9 +220,7 @@ export function GamesList({
                     </Badge>
                   </span>
                   <span>
-                    {toDateString(
-                      toLocalDateTime(game.matchdayGame.matchday.date),
-                    )}
+                    {formatDateOnly(game.matchdayGame.matchday.date)}
                   </span>
                 </div>
                 <div className="flex items-center gap-2">
@@ -273,7 +259,7 @@ export function GamesList({
                       currentResult={game.result}
                       onResultChange={onResultChange}
                       availableMatchdays={availableMatchdays}
-                      currentGameDate={toLocalDateTime(
+                      currentGameDate={parseDateOnly(
                         game.matchdayGame.matchday.date,
                       )}
                       game={game}

--- a/src/components/partien/partien-selector.tsx
+++ b/src/components/partien/partien-selector.tsx
@@ -14,8 +14,8 @@ import { Calendar } from "../ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { CalendarIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { format } from "date-fns";
-import { de } from "date-fns/locale";
+import { TZDate } from "react-day-picker";
+import { formatDateOnly, utcDateToDateOnly } from "@/lib/date";
 import type { GroupSummary } from "@/db/types/group";
 import type { ParticipantWithName } from "@/db/types/participant";
 import type { MatchDay } from "@/db/types/match-day";
@@ -112,10 +112,9 @@ export function PartienSelector({
       return;
     }
 
-    const matchday = matchdays.find((md) => {
-      const mdDate = new Date(md.date);
-      return mdDate.toDateString() === date.toDateString();
-    });
+    const matchday = matchdays.find(
+      (md) => md.date === utcDateToDateOnly(date),
+    );
 
     if (matchday) {
       handleMatchdayChange(matchday.id.toString());
@@ -142,9 +141,7 @@ export function PartienSelector({
               >
                 <CalendarIcon className="mr-2 h-4 w-4" />
                 {selectedMatchday ? (
-                  format(new Date(selectedMatchday.date), "dd.MM.yyyy", {
-                    locale: de,
-                  })
+                  formatDateOnly(selectedMatchday.date)
                 ) : (
                   <span>Datum wählen</span>
                 )}
@@ -153,16 +150,16 @@ export function PartienSelector({
             <PopoverContent className="w-auto p-0">
               <Calendar
                 mode="single"
+                timeZone="UTC"
                 selected={
-                  selectedMatchday ? new Date(selectedMatchday.date) : undefined
+                  selectedMatchday
+                    ? new TZDate(selectedMatchday.date, "UTC")
+                    : undefined
                 }
                 onSelect={handleDateChange}
-                disabled={(date) => {
-                  return !matchdays.some((md) => {
-                    const mdDate = new Date(md.date);
-                    return mdDate.toDateString() === date.toDateString();
-                  });
-                }}
+                disabled={(date) =>
+                  !matchdays.some((md) => md.date === utcDateToDateOnly(date))
+                }
               />
             </PopoverContent>
           </Popover>

--- a/src/components/partien/postpone-game-dialog.tsx
+++ b/src/components/partien/postpone-game-dialog.tsx
@@ -23,7 +23,12 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { Card, CardContent } from "../ui/card";
 import { Mail, Phone } from "lucide-react";
-import { isSameDate, toLocalDateTime, toDateString } from "@/lib/date";
+import {
+  toLocalDateTime,
+  formatDate,
+  toDateOnly,
+  utcDateToDateOnly,
+} from "@/lib/date";
 import invariant from "tiny-invariant";
 import { DateTime } from "luxon";
 
@@ -56,8 +61,8 @@ export function PostponeGameDialog({
 
     if (!selectedDate) return;
 
-    const selectedMatchday = availableMatchdays.find((matchday) =>
-      isSameDate(toLocalDateTime(matchday.date), toLocalDateTime(selectedDate)),
+    const selectedMatchday = availableMatchdays.find(
+      (matchday) => matchday.date === utcDateToDateOnly(selectedDate),
     );
 
     if (!selectedMatchday) return;
@@ -81,14 +86,13 @@ export function PostponeGameDialog({
     });
   };
 
-  const isDateDisabled = (date: DateTime) => {
-    if (isSameDate(date, currentGameDate)) {
+  const isDateDisabled = (date: Date) => {
+    const day = utcDateToDateOnly(date);
+    if (day === toDateOnly(currentGameDate)) {
       return true;
     }
 
-    return !availableMatchdays.some((matchday) =>
-      isSameDate(toLocalDateTime(matchday.date), date),
-    );
+    return !availableMatchdays.some((matchday) => matchday.date === day);
   };
 
   const handleOpenChange = (open: boolean) => {
@@ -174,7 +178,7 @@ export function PostponeGameDialog({
                 >
                   <CalendarIcon className="mr-2 h-4 w-4 opacity-50" />
                   {selectedDate ? (
-                    toDateString(toLocalDateTime(selectedDate))
+                    formatDate(toLocalDateTime(selectedDate))
                   ) : (
                     <span>Datum wählen</span>
                   )}
@@ -183,9 +187,10 @@ export function PostponeGameDialog({
               <PopoverContent className="w-auto p-0" align="start">
                 <Calendar
                   mode="single"
+                  timeZone="UTC"
                   selected={selectedDate}
                   onSelect={setSelectedDate}
-                  disabled={(date) => isDateDisabled(toLocalDateTime(date))}
+                  disabled={isDateDisabled}
                 />
               </PopoverContent>
             </Popover>

--- a/src/components/postponements/postponement-grid.tsx
+++ b/src/components/postponements/postponement-grid.tsx
@@ -9,7 +9,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { toDateString, toLocalDateTime } from "@/lib/date";
+import { formatDate, toLocalDateTime } from "@/lib/date";
 import type { GamePostponementWithDetails } from "@/db/types/game-postponement";
 import { CalendarDays } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -133,12 +133,12 @@ export function PostponementGrid({ postponements }: Props) {
                 </TableCell>
                 <TableCell className="hidden md:table-cell w-24 text-center align-middle">
                   <span className="text-sm">
-                    {toDateString(toLocalDateTime(postponement.from))}
+                    {formatDate(toLocalDateTime(postponement.from))}
                   </span>
                 </TableCell>
                 <TableCell className="hidden md:table-cell w-24 text-center align-middle">
                   <span className="text-sm font-medium">
-                    {toDateString(toLocalDateTime(postponement.to))}
+                    {formatDate(toLocalDateTime(postponement.to))}
                   </span>
                 </TableCell>
                 <TableCell className="w-32 truncate align-middle">

--- a/src/components/terminuebersicht/appointment-card.tsx
+++ b/src/components/terminuebersicht/appointment-card.tsx
@@ -13,7 +13,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Clock, ChevronRight, X, Undo2 } from "lucide-react";
-import { formatEventDateTime, toLocalDateTime } from "@/lib/date";
+import { formatEventDateTime, parseDateOnly } from "@/lib/date";
 import { getDateTimeFromTournamentTime } from "@/lib/game-time";
 import { buildGameViewUrl } from "@/lib/navigation";
 import { useTournamentSlug } from "@/hooks/use-tournament-slug";
@@ -80,7 +80,7 @@ export function MatchdayAppointmentCard({ appointment }: Props) {
       <CardHeader className="pb-4">
         <div className="flex items-center justify-between">
           <h2 className="text-2xl font-bold">
-            {toLocalDateTime(matchdayDate).setLocale("de").weekdayLong}
+            {parseDateOnly(matchdayDate).setLocale("de").weekdayLong}
           </h2>
           <div className="flex items-center gap-2">
             <Link href={gameUrl}>

--- a/src/components/uebersicht/registration/countdown-timer.tsx
+++ b/src/components/uebersicht/registration/countdown-timer.tsx
@@ -2,10 +2,10 @@
 
 import { match } from "ts-pattern";
 import { useEffect, useState } from "react";
-import { getCurrentLocalDateTime, toLocalDateTime } from "@/lib/date";
+import { getCurrentLocalDateTime, parseDateOnly } from "@/lib/date";
 
 type Props = {
-  date: Date;
+  date: string;
 };
 
 export function CountdownTimer({ date }: Props) {
@@ -58,12 +58,10 @@ function Timers({ timeLeft }: { timeLeft: TimeLeft }) {
   );
 }
 
-function calculateTimeLeft(date: Date) {
+function calculateTimeLeft(date: string) {
   const currentLocalTime = getCurrentLocalDateTime();
 
-  const endOfRegistrationDate = new Date(date);
-  endOfRegistrationDate.setHours(23, 59, 59, 999);
-  const targetTime = toLocalDateTime(endOfRegistrationDate);
+  const targetTime = parseDateOnly(date).endOf("day");
 
   const diff = targetTime.diff(currentLocalTime, [
     "days",

--- a/src/components/uebersicht/registration/tournament-weeks.tsx
+++ b/src/components/uebersicht/registration/tournament-weeks.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/table";
 import { TournamentWeekWithMatchdays } from "@/db/types/tournamentWeek";
 
-import { displayShortDateOrHoliday } from "@/lib/date";
+import { formatShortDateOrHoliday } from "@/lib/date";
 import { generateTournamentWeeksSchedule } from "@/lib/tournament-schedule";
 
 type Props = {
@@ -43,13 +43,13 @@ export function TournamentWeeks({ tournamentWeeks }: Props) {
               {week.weekLabel}
             </TableCell>
             <TableCell className="text-center">
-              {displayShortDateOrHoliday(week.tuesday)}
+              {formatShortDateOrHoliday(week.tuesday)}
             </TableCell>
             <TableCell className="text-center">
-              {displayShortDateOrHoliday(week.thursday)}
+              {formatShortDateOrHoliday(week.thursday)}
             </TableCell>
             <TableCell className="text-center">
-              {displayShortDateOrHoliday(week.friday)}
+              {formatShortDateOrHoliday(week.friday)}
             </TableCell>
           </TableRow>
         ))}

--- a/src/db/repositories/appointment.ts
+++ b/src/db/repositories/appointment.ts
@@ -14,7 +14,7 @@ import { and, eq, gte, asc, ne, inArray } from "drizzle-orm";
 
 export async function getRefereeAppointmentsByRefereeId(
   refereeId: number,
-  fromDate: Date,
+  fromDate: string,
 ) {
   return db
     .select({
@@ -39,7 +39,7 @@ export async function getRefereeAppointmentsByRefereeId(
 
 export async function getSetupHelperAppointmentsBySetupHelperId(
   setupHelperId: number,
-  fromDate: Date,
+  fromDate: string,
 ) {
   return db
     .select({

--- a/src/db/repositories/game.ts
+++ b/src/db/repositories/game.ts
@@ -8,8 +8,9 @@ import {
   getTableColumns,
   isNull,
   isNotNull,
+  lte,
 } from "drizzle-orm";
-import { getCurrentLocalDateTime } from "@/lib/date";
+import { todayDateOnly } from "@/lib/date";
 import { getDateTimeFromTournamentTime } from "@/lib/game-time";
 import { group } from "../schema/group";
 import { matchdayGame, matchdayReferee } from "../schema/matchday";
@@ -417,7 +418,7 @@ export async function getPendingGamesByParticipantId(participantId: number) {
           eq(game.blackParticipantId, participantId),
         ),
         isNull(game.result),
-        sql`${matchday.date} < ${getCurrentLocalDateTime()}`,
+        lte(matchday.date, todayDateOnly()),
       ),
     )
     .orderBy(asc(matchday.date))
@@ -438,7 +439,7 @@ export async function getPendingGamesByRefereeId(refereeId: number) {
       and(
         eq(matchdayReferee.refereeId, refereeId),
         isNull(game.result),
-        sql`${matchday.date} < ${getCurrentLocalDateTime()}`,
+        lte(matchday.date, todayDateOnly()),
       ),
     )
     .orderBy(asc(matchday.date))

--- a/src/db/schema/matchday.ts
+++ b/src/db/schema/matchday.ts
@@ -18,7 +18,7 @@ export const matchday = pgTable("matchday", {
   id: integer("id").generatedAlwaysAsIdentity().primaryKey(),
   tournamentId: integer("tournament_id").notNull(),
   tournamentWeekId: integer("tournament_week_id").notNull(),
-  date: date("date", { mode: "date" }).notNull(),
+  date: date("date", { mode: "string" }).notNull(),
   dayOfWeek: matchDay("day_of_week").notNull(), // tuesday, thursday, friday
   refereeNeeded: boolean("referee_needed").notNull().default(true),
 

--- a/src/db/schema/participant.ts
+++ b/src/db/schema/participant.ts
@@ -27,14 +27,14 @@ export const participant = pgTable(
     dwzRating: integer("dwz_rating"),
     fideRating: integer("fide_rating"),
     birthYear: integer("birth_year"),
-    birthDate: date("birth_date", { mode: "date" }),
+    birthDate: date("birth_date", { mode: "string" }),
     fideId: text("fide_id"),
     zpsClubId: text("zps_club_id"),
     zpsPlayerId: text("zps_player_id"),
 
     preferredMatchDay: matchDay("preferred_match_day").notNull(),
     secondaryMatchDays: matchDay("secondary_match_days").array().notNull(),
-    notAvailableDays: date("not_available_days", { mode: "date" }).array(),
+    notAvailableDays: date("not_available_days", { mode: "string" }).array(),
 
     entryFeePayed: boolean("entry_fee_payed"),
 

--- a/src/db/schema/tournament.ts
+++ b/src/db/schema/tournament.ts
@@ -29,14 +29,14 @@ export const tournament = pgTable("tournament", {
   type: text("type").notNull(),
   numberOfRounds: smallint("number_of_rounds").notNull(),
   endRegistrationDate: date("end_registration_date", {
-    mode: "date",
+    mode: "string",
   }).notNull(),
   groupAnnouncementOffsetDays: smallint("group_announcement_offset_days")
     .notNull()
     .default(2),
 
-  startDate: date("start_date", { mode: "date" }).notNull(),
-  endDate: date("end_date", { mode: "date" }).notNull(),
+  startDate: date("start_date", { mode: "string" }).notNull(),
+  endDate: date("end_date", { mode: "string" }).notNull(),
   timeLimit: text("time_limit").notNull(),
   location: text("location").notNull(),
   allClocksDigital: boolean("all_clocks_digital").notNull(),

--- a/src/db/types/game-postponement.ts
+++ b/src/db/types/game-postponement.ts
@@ -17,7 +17,7 @@ export type GamePostponementWithDetails = GamePostponement & {
     matchdayGame: {
       matchday: {
         id: number;
-        date: Date;
+        date: string;
       };
     } | null;
   };

--- a/src/db/types/game.ts
+++ b/src/db/types/game.ts
@@ -51,7 +51,7 @@ export type GameWithParticipantProfilesAndGroupAndMatchday = Game & {
   };
   matchdayGame: {
     matchday: {
-      date: Date;
+      date: string;
     };
   };
   pgn: {
@@ -62,7 +62,7 @@ export type GameWithParticipantProfilesAndGroupAndMatchday = Game & {
 export type GameWithMatchday = Game & {
   matchdayGame: {
     matchday: {
-      date: Date;
+      date: string;
     };
   };
 };
@@ -72,7 +72,7 @@ export type GameWithParticipantProfilesAndMatchday = Game & {
   blackParticipant: ParticipantWithProfile | null;
   matchdayGame: {
     matchday: {
-      date: Date;
+      date: string;
     };
   };
 };
@@ -80,7 +80,7 @@ export type GameWithParticipantProfilesAndMatchday = Game & {
 export type GameWithParticipantsAndDate = GameWithParticipants & {
   matchdayGame: {
     matchday: {
-      date: Date;
+      date: string;
     };
   };
 };
@@ -92,7 +92,7 @@ export type GameWithParticipantsAndPGNAndDate = GameWithParticipantsAndPGN & {
   };
   matchdayGame: {
     matchday: {
-      date: Date;
+      date: string;
     };
   };
 };

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, afterEach, vi } from "vitest";
+import {
+  parseDateOnly,
+  toDateOnly,
+  utcDateToDateOnly,
+  todayDateOnly,
+  formatDateOnly,
+} from "../date";
+
+describe("parseDateOnly", () => {
+  test("interprets the string as a Berlin calendar day", () => {
+    const dt = parseDateOnly("2026-12-10");
+    expect(dt.zoneName).toBe("Europe/Berlin");
+    expect(dt.year).toBe(2026);
+    expect(dt.month).toBe(12);
+    expect(dt.day).toBe(10);
+    expect(dt.weekday).toBe(4);
+  });
+
+  test("round-trips through toDateOnly", () => {
+    expect(toDateOnly(parseDateOnly("2026-12-10"))).toBe("2026-12-10");
+    expect(toDateOnly(parseDateOnly("2026-01-01"))).toBe("2026-01-01");
+  });
+});
+
+describe("utcDateToDateOnly", () => {
+  test("keeps the calendar day of a UTC-midnight picker date", () => {
+    expect(utcDateToDateOnly(new Date("2026-12-10T00:00:00Z"))).toBe(
+      "2026-12-10",
+    );
+  });
+
+  test("regression: Berlin winter local midnight is NOT shifted when picker runs in UTC", () => {
+    const berlinLocalMidnightAsUtc = new Date("2026-12-09T23:00:00Z");
+    expect(utcDateToDateOnly(berlinLocalMidnightAsUtc)).toBe("2026-12-09");
+    const pickerUtcDate = new Date("2026-12-10T00:00:00Z");
+    expect(utcDateToDateOnly(pickerUtcDate)).toBe("2026-12-10");
+  });
+});
+
+describe("formatDateOnly", () => {
+  test("formats German day.month.year with padding", () => {
+    expect(formatDateOnly("2026-12-10")).toBe("10.12.2026");
+    expect(formatDateOnly("2026-01-05")).toBe("05.01.2026");
+  });
+});
+
+describe("todayDateOnly", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("returns the Berlin calendar day, not the UTC day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-12-09T23:30:00Z"));
+    expect(todayDateOnly()).toBe("2026-12-10");
+  });
+
+  test("agrees with UTC during the day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-12-10T12:00:00Z"));
+    expect(todayDateOnly()).toBe("2026-12-10");
+  });
+});
+
+describe("date-only string comparisons", () => {
+  test("ISO strings compare lexicographically in day order", () => {
+    expect("2026-01-05" < "2026-12-10").toBe(true);
+    expect("2026-12-09" < "2026-12-10").toBe(true);
+    expect("2025-12-31" < "2026-01-01").toBe(true);
+  });
+});

--- a/src/lib/__tests__/game-time.test.ts
+++ b/src/lib/__tests__/game-time.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "vitest";
+import {
+  getDateTimeFromTournamentTime,
+  getSetupHelperTimeFromTournamentTime,
+  formatGameTimeByTournament,
+} from "../game-time";
+
+describe("getDateTimeFromTournamentTime", () => {
+  test("builds the game start as Berlin time on the matchday", () => {
+    const dt = getDateTimeFromTournamentTime("2026-12-10", "19:30:00");
+    expect(dt.zoneName).toBe("Europe/Berlin");
+    expect(dt.toISODate()).toBe("2026-12-10");
+    expect(dt.hour).toBe(19);
+    expect(dt.minute).toBe(30);
+  });
+
+  test("winter matchday: 19:30 Berlin is 18:30 UTC (CET, +1)", () => {
+    const dt = getDateTimeFromTournamentTime("2026-12-10", "19:30:00");
+    expect(dt.toUTC().toISO()).toBe("2026-12-10T18:30:00.000Z");
+  });
+
+  test("summer matchday: 19:30 Berlin is 17:30 UTC (CEST, +2)", () => {
+    const dt = getDateTimeFromTournamentTime("2026-07-02", "19:30:00");
+    expect(dt.toUTC().toISO()).toBe("2026-07-02T17:30:00.000Z");
+  });
+});
+
+describe("getSetupHelperTimeFromTournamentTime", () => {
+  test("is 30 minutes before game start on the same day", () => {
+    const dt = getSetupHelperTimeFromTournamentTime("2026-12-10", "19:30:00");
+    expect(dt.toISODate()).toBe("2026-12-10");
+    expect(dt.hour).toBe(19);
+    expect(dt.minute).toBe(0);
+  });
+});
+
+describe("formatGameTimeByTournament", () => {
+  test("formats HH:MM Uhr with padding", () => {
+    expect(formatGameTimeByTournament("19:30:00")).toBe("19:30 Uhr");
+    expect(formatGameTimeByTournament("9:05:00")).toBe("09:05 Uhr");
+  });
+});

--- a/src/lib/chess-utils.ts
+++ b/src/lib/chess-utils.ts
@@ -3,7 +3,7 @@ import invariant from "tiny-invariant";
 import { GameWithParticipantsAndPGNAndDate } from "@/db/types/game";
 import { getParticipantFullName } from "@/lib/participant";
 import { getGameTimeFromGame } from "@/lib/game-time";
-import { toDateString } from "@/lib/date";
+import { formatDate } from "@/lib/date";
 
 //TODO: cleanup db entries, all results shall be stored with a "-", also remove "½" and replace with "1/2"
 function normalizeResult(result: string): string {
@@ -20,7 +20,7 @@ export function getHeadersFromGame(
   return {
     Event: game.tournament.name,
     Site: "https://klubturnier.hsk1830.de",
-    Date: toDateString(
+    Date: formatDate(
       getGameTimeFromGame(game, game.tournament.gameStartTime),
     ),
     Round: game.round.toString(),

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -2,16 +2,18 @@ import { DateTime } from "luxon";
 import invariant from "tiny-invariant";
 import { isHoliday } from "./holidays";
 
+export const EVENT_TIME_ZONE = "Europe/Berlin";
+
 export function getCurrentLocalDateTime(): DateTime {
-  return DateTime.now().setZone("Europe/Berlin");
+  return DateTime.now().setZone(EVENT_TIME_ZONE);
 }
 
 export function toLocalDateTime(date: Date): DateTime {
-  return DateTime.fromJSDate(date).setZone("Europe/Berlin");
+  return DateTime.fromJSDate(date).setZone(EVENT_TIME_ZONE);
 }
 
 export function parseDateOnly(date: string): DateTime {
-  return DateTime.fromISO(date, { zone: "Europe/Berlin" });
+  return DateTime.fromISO(date, { zone: EVENT_TIME_ZONE });
 }
 
 export function toDateOnly(date: DateTime): string {

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -9,12 +9,24 @@ export function toLocalDateTime(date: Date): DateTime {
   return DateTime.fromJSDate(date).setZone("Europe/Berlin");
 }
 
-export function getDatetimeString(date: DateTime) {
-  return date.toFormat("dd.MM.yyyy HH:mm");
+export function parseDateOnly(date: string): DateTime {
+  return DateTime.fromISO(date, { zone: "Europe/Berlin" });
 }
 
-export function isSameDate(date1: DateTime, date2: DateTime): boolean {
-  return date1.hasSame(date2, "day");
+export function toDateOnly(date: DateTime): string {
+  return date.toISODate()!;
+}
+
+export function utcDateToDateOnly(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export function todayDateOnly(): string {
+  return getCurrentLocalDateTime().toISODate()!;
+}
+
+export function formatDateOnly(date: string): string {
+  return parseDateOnly(date).toFormat("dd.MM.yyyy");
 }
 
 /**
@@ -22,7 +34,7 @@ export function isSameDate(date1: DateTime, date2: DateTime): boolean {
  * @param date - The DateTime object to format
  * @returns Formatted date string or "Feiertag"
  */
-export function displayShortDateOrHoliday(date: DateTime): string {
+export function formatShortDateOrHoliday(date: DateTime): string {
   if (isHoliday(date.toJSDate())) {
     return "Feiertag";
   }
@@ -34,7 +46,7 @@ export function displayShortDateOrHoliday(date: DateTime): string {
  * @param date - The date to format
  * @returns A formatted date string like "Donnerstag, 15. August 2024"
  */
-export function displayLongDate(date: DateTime): string {
+export function formatLongDate(date: DateTime): string {
   return date.setLocale("de-DE").toFormat("cccc, d. LLLL yyyy");
 }
 
@@ -50,10 +62,10 @@ export function formatEventDateTime(date: DateTime): string {
 }
 
 /**
- * Formats a game date for display in German locale (DD.MM.YYYY format)
- * @param date - The game date/time to format
+ * Formats a date for display in German locale (DD.MM.YYYY format)
+ * @param date - The date/time to format
  * @returns A formatted date string in German format
  */
-export function toDateString(date: DateTime): string {
+export function formatDate(date: DateTime): string {
   return date.toFormat("dd.MM.yyyy");
 }

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon";
+import invariant from "tiny-invariant";
 import { isHoliday } from "./holidays";
 
 export function getCurrentLocalDateTime(): DateTime {
@@ -14,7 +15,13 @@ export function parseDateOnly(date: string): DateTime {
 }
 
 export function toDateOnly(date: DateTime): string {
-  return date.toISODate()!;
+  const isoDate = date.toISODate();
+  invariant(isoDate, "Invalid DateTime");
+  return isoDate;
+}
+
+export function isValidDateOnly(date: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) && parseDateOnly(date).isValid;
 }
 
 export function utcDateToDateOnly(date: Date): string {
@@ -22,11 +29,11 @@ export function utcDateToDateOnly(date: Date): string {
 }
 
 export function todayDateOnly(): string {
-  return getCurrentLocalDateTime().toISODate()!;
+  return toDateOnly(getCurrentLocalDateTime());
 }
 
 export function formatDateOnly(date: string): string {
-  return parseDateOnly(date).toFormat("dd.MM.yyyy");
+  return formatDate(parseDateOnly(date));
 }
 
 /**

--- a/src/lib/dwz-report/dwz-report.spec.ts
+++ b/src/lib/dwz-report/dwz-report.spec.ts
@@ -117,8 +117,8 @@ const headerSectionData: HeaderSectionData = {
 const tournamentSectionData: TournamentSectionData = {
   tournamentName: "Klubturnier 2025",
   location: "Hamburg",
-  startDate: new Date("2025-09-16"),
-  endDate: new Date("2025-12-12"),
+  startDate: "2025-09-16",
+  endDate: "2025-12-12",
   timeLimit:
     "40 Züge in 90 Minuten, danach 0 Züge in 0 Minuten, 30 Minuten für die letzte Phase, Zugabe pro Zug in Sekunden: 30",
   tournamentOrganizer: "Arne Alpers",

--- a/src/lib/dwz-report/tournament-section.ts
+++ b/src/lib/dwz-report/tournament-section.ts
@@ -1,3 +1,4 @@
+import { parseDateOnly } from "@/lib/date";
 import { TournamentSectionData } from "./types";
 
 export function generateTournamentSection(
@@ -12,6 +13,6 @@ Turnierorganisator: ${tournamentSectionData.tournamentOrganizer}\r
 Hauptschiedsrichter: ${tournamentSectionData.mainReferee}\r`;
 }
 
-function formatDate(date: Date) {
-  return date.toLocaleDateString("de-DE");
+function formatDate(date: string) {
+  return parseDateOnly(date).toFormat("d.M.yyyy");
 }

--- a/src/lib/dwz-report/types.ts
+++ b/src/lib/dwz-report/types.ts
@@ -30,8 +30,8 @@ export type TournamentSectionData = {
   tournamentName?: string;
   location?: string;
   fideFederation?: string;
-  startDate: Date;
-  endDate: Date;
+  startDate: string;
+  endDate: string;
   timeLimit?: string;
   tournamentOrganizer?: string;
   mainReferee?: string;

--- a/src/lib/game-time.ts
+++ b/src/lib/game-time.ts
@@ -1,52 +1,49 @@
 import { GameWithMatchday } from "@/db/types/game";
+import { parseDateOnly } from "@/lib/date";
 import { DateTime } from "luxon";
 import invariant from "tiny-invariant";
 
 /**
- * Creates a Date object for a game with the specified matchday date and game start time
- * @param matchdayDate - The date of the matchday (Date object or string)
+ * Creates a DateTime for a game with the specified matchday date and game start time
+ * @param matchdayDate - The date of the matchday ('YYYY-MM-DD' string)
  * @param gameStartTime - The game start time in HH:MM:SS format
- * @returns A Date object with the game date and time
+ * @returns A DateTime with the game date and time in Europe/Berlin
  */
 export function getDateTimeFromTournamentTime(
-  matchdayDate: Date,
+  matchdayDate: string,
   gameStartTime: string,
 ) {
   invariant(gameStartTime, "Game start time is required");
 
   const [hours, minutes, seconds] = gameStartTime.split(":").map(Number);
 
-  const gameDateTime = DateTime.fromJSDate(matchdayDate)
-    .setZone("Europe/Berlin")
-    .set({
-      hour: hours,
-      minute: minutes,
-      second: seconds,
-    });
+  const gameDateTime = parseDateOnly(matchdayDate).set({
+    hour: hours,
+    minute: minutes,
+    second: seconds,
+  });
   return gameDateTime;
 }
 
 /**
- * Creates a Date object for setup helper with the specified matchday date and 30 minutes before game start time
- * @param matchdayDate - The date of the matchday (Date object or string)
+ * Creates a DateTime for setup helper with the specified matchday date and 30 minutes before game start time
+ * @param matchdayDate - The date of the matchday ('YYYY-MM-DD' string)
  * @param gameStartTime - The game start time in HH:MM:SS format
- * @returns A Date object with the setup helper date and time
+ * @returns A DateTime with the setup helper date and time in Europe/Berlin
  */
 export function getSetupHelperTimeFromTournamentTime(
-  matchdayDate: Date,
+  matchdayDate: string,
   gameStartTime: string,
 ): DateTime {
   invariant(gameStartTime, "Game start time is required");
 
   const [hours, minutes, seconds] = gameStartTime.split(":").map(Number);
 
-  const setupDateTime = DateTime.fromJSDate(matchdayDate)
-    .setZone("Europe/Berlin")
-    .set({
-      hour: hours,
-      minute: minutes - 30,
-      second: seconds,
-    });
+  const setupDateTime = parseDateOnly(matchdayDate).set({
+    hour: hours,
+    minute: minutes - 30,
+    second: seconds,
+  });
   return setupDateTime;
 }
 

--- a/src/lib/pairing-utils.ts
+++ b/src/lib/pairing-utils.ts
@@ -1,30 +1,3 @@
-const weekdayToIndex = {
-  monday: 1,
-  tuesday: 2,
-  wednesday: 3,
-  thursday: 4,
-  friday: 5,
-  saturday: 6,
-  sunday: 0,
-} as const;
-
-export function addDays(d: Date, days: number) {
-  const out = new Date(d);
-  out.setDate(out.getDate() + days);
-  return out;
-}
-
-/** first date ≥ `start` that falls on the wanted `weekday`              */
-export function firstMatchDate(
-  start: Date,
-  weekday: keyof typeof weekdayToIndex,
-) {
-  const wanted = weekdayToIndex[weekday];
-  const d = new Date(start);
-  while (d.getDay() !== wanted) d.setDate(d.getDate() + 1);
-  return d;
-}
-
 export function bergerFide(n: number): Array<Array<[number, number]>> {
   if (n % 2) {
     throw new Error("n must be even (add a bye for odd n)");
@@ -76,5 +49,3 @@ export function bergerFide(n: number): Array<Array<[number, number]>> {
 export function nextEvenNumber(n: number): number {
   return n + (n % 2);
 }
-
-export type WeekdayKey = keyof typeof weekdayToIndex;

--- a/src/lib/tournament-schedule.ts
+++ b/src/lib/tournament-schedule.ts
@@ -1,6 +1,6 @@
 import invariant from "tiny-invariant";
 import { Tournament } from "@/db/types/tournament";
-import { toDateString, toLocalDateTime } from "./date";
+import { parseDateOnly, formatDate } from "./date";
 
 export function getGroupAnnouncementDate(
   tournament: Pick<
@@ -8,8 +8,8 @@ export function getGroupAnnouncementDate(
     "endRegistrationDate" | "groupAnnouncementOffsetDays"
   >,
 ): string {
-  return toDateString(
-    toLocalDateTime(tournament.endRegistrationDate).plus({
+  return formatDate(
+    parseDateOnly(tournament.endRegistrationDate).plus({
       days: tournament.groupAnnouncementOffsetDays,
     }),
   );
@@ -19,7 +19,7 @@ export function generateTournamentWeeksSchedule(
   tournamentWeeks: Array<{
     id: number;
     status: "regular" | "catch-up";
-    matchdays: Array<{ date: Date }>;
+    matchdays: Array<{ date: string }>;
   }>,
 ) {
   let regularWeekCount = 0;
@@ -35,7 +35,7 @@ export function generateTournamentWeeksSchedule(
       week.matchdays[0],
       `Tournament week ${week.id} has no matchdays`,
     );
-    const weekStart = toLocalDateTime(week.matchdays[0].date).startOf("week");
+    const weekStart = parseDateOnly(week.matchdays[0].date).startOf("week");
 
     return {
       id: week.id,
@@ -48,7 +48,7 @@ export function generateTournamentWeeksSchedule(
 }
 
 export function generateRefereeAssignmentSchedule<
-  TMatchday extends { date: Date },
+  TMatchday extends { date: string },
   TWeek extends { weekNumber: number; status: "regular" | "catch-up" },
 >(
   groupedMatchdays: Record<
@@ -78,7 +78,7 @@ export function generateRefereeAssignmentSchedule<
       entry.matchdays[0],
       `Tournament week ${week.weekNumber} has no matchdays`,
     );
-    const weekStart = toLocalDateTime(entry.matchdays[0].date).startOf("week");
+    const weekStart = parseDateOnly(entry.matchdays[0].date).startOf("week");
 
     const tuesday = weekStart.plus({ days: 1 });
     const thursday = weekStart.plus({ days: 3 });

--- a/src/schema/__tests__/participant.test.ts
+++ b/src/schema/__tests__/participant.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect, afterEach, vi } from "vitest";
+import { participantFormSchema } from "../participant";
+
+const validBase = {
+  chessClubType: "hsk" as const,
+  preferredMatchDay: "tuesday" as const,
+  secondaryMatchDays: [],
+};
+
+describe("participantFormSchema birthDate", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("accepts a valid YYYY-MM-DD date", () => {
+    const result = participantFormSchema.safeParse({
+      ...validBase,
+      birthDate: "1990-01-01",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects German or unpadded formats", () => {
+    for (const birthDate of ["10.12.1990", "1990-1-1", "1990-12-9"]) {
+      const result = participantFormSchema.safeParse({
+        ...validBase,
+        birthDate,
+      });
+      expect(result.success).toBe(false);
+    }
+  });
+
+  test("rejects a birth date in the future (Berlin today)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-02T12:00:00Z"));
+    const result = participantFormSchema.safeParse({
+      ...validBase,
+      birthDate: "2026-07-03",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("participantFormSchema notAvailableDays", () => {
+  test("accepts up to 5 valid days", () => {
+    const result = participantFormSchema.safeParse({
+      ...validBase,
+      notAvailableDays: [
+        "2026-09-29",
+        "2026-10-29",
+        "2026-11-12",
+        "2026-12-10",
+        "2026-12-11",
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects more than 5 days", () => {
+    const result = participantFormSchema.safeParse({
+      ...validBase,
+      notAvailableDays: [
+        "2026-09-29",
+        "2026-10-29",
+        "2026-11-12",
+        "2026-12-10",
+        "2026-12-11",
+        "2026-12-15",
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects timestamps and non-ISO strings", () => {
+    for (const day of ["2026-12-10T00:00:00Z", "10.12.2026", "invalid"]) {
+      const result = participantFormSchema.safeParse({
+        ...validBase,
+        notAvailableDays: [day],
+      });
+      expect(result.success).toBe(false);
+    }
+  });
+});

--- a/src/schema/__tests__/participant.test.ts
+++ b/src/schema/__tests__/participant.test.ts
@@ -30,6 +30,16 @@ describe("participantFormSchema birthDate", () => {
     }
   });
 
+  test("rejects calendar-impossible dates", () => {
+    for (const birthDate of ["1990-02-30", "1990-13-01", "1990-11-31"]) {
+      const result = participantFormSchema.safeParse({
+        ...validBase,
+        birthDate,
+      });
+      expect(result.success).toBe(false);
+    }
+  });
+
   test("rejects a birth date in the future (Berlin today)", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-02T12:00:00Z"));

--- a/src/schema/participant.ts
+++ b/src/schema/participant.ts
@@ -1,7 +1,13 @@
 import { CLUBLESS_KEY, DEFAULT_CLUB_KEY } from "@/constants/constants";
 import { availableMatchDays } from "@/db/schema/columns.helpers";
-import { getCurrentLocalDateTime, todayDateOnly } from "@/lib/date";
+import {
+  getCurrentLocalDateTime,
+  isValidDateOnly,
+  todayDateOnly,
+} from "@/lib/date";
 import z from "zod";
+
+const dateOnlySchema = z.string().refine(isValidDateOnly, "Ungültiges Datum");
 
 export const participantFormSchema = z
   .object({
@@ -33,9 +39,7 @@ export const participantFormSchema = z
         "Geburtsjahr kann nicht in der Zukunft liegen",
       )
       .optional(),
-    birthDate: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/, "Ungültiges Geburtsdatum")
+    birthDate: dateOnlySchema
       .refine(
         (d) => d <= todayDateOnly(),
         "Geburtsdatum kann nicht in der Zukunft liegen",
@@ -51,7 +55,7 @@ export const participantFormSchema = z
     }),
     secondaryMatchDays: z.array(z.enum(availableMatchDays)),
     notAvailableDays: z
-      .array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/))
+      .array(dateOnlySchema)
       .max(5, "Maximal 5 Tage")
       .optional(),
     exercisePromotionRight: z.boolean().optional(),

--- a/src/schema/participant.ts
+++ b/src/schema/participant.ts
@@ -1,5 +1,6 @@
 import { CLUBLESS_KEY, DEFAULT_CLUB_KEY } from "@/constants/constants";
 import { availableMatchDays } from "@/db/schema/columns.helpers";
+import { getCurrentLocalDateTime, todayDateOnly } from "@/lib/date";
 import z from "zod";
 
 export const participantFormSchema = z
@@ -28,14 +29,15 @@ export const participantFormSchema = z
       .number()
       .min(1900, "Geburtsjahr muss mindestens 1900 sein")
       .refine(
-        (y) => y <= new Date().getFullYear(),
+        (y) => y <= getCurrentLocalDateTime().year,
         "Geburtsjahr kann nicht in der Zukunft liegen",
       )
       .optional(),
-    birthDate: z.coerce
-      .date()
+    birthDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Ungültiges Geburtsdatum")
       .refine(
-        (d) => d <= new Date(),
+        (d) => d <= todayDateOnly(),
         "Geburtsdatum kann nicht in der Zukunft liegen",
       )
       .optional(),
@@ -48,7 +50,10 @@ export const participantFormSchema = z
       errorMap: () => ({ message: "Bevorzugter Spieltag ist erforderlich" }),
     }),
     secondaryMatchDays: z.array(z.enum(availableMatchDays)),
-    notAvailableDays: z.array(z.date()).max(5, "Maximal 5 Tage").optional(),
+    notAvailableDays: z
+      .array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/))
+      .max(5, "Maximal 5 Tage")
+      .optional(),
     exercisePromotionRight: z.boolean().optional(),
   })
   .refine(
@@ -97,7 +102,7 @@ export const participantFormSchema = z
         return (
           !!data.birthYear &&
           data.birthYear >= 1900 &&
-          data.birthYear <= new Date().getFullYear()
+          data.birthYear <= getCurrentLocalDateTime().year
         );
       }
       return true;

--- a/src/services/appointment.ts
+++ b/src/services/appointment.ts
@@ -6,7 +6,7 @@ import {
 import { getProfileByUserId } from "@/db/repositories/profile";
 import { getRefereeByUserId } from "@/db/repositories/referee";
 import { getSetupHelperByUserId } from "@/db/repositories/setup-helper";
-import { getCurrentLocalDateTime } from "@/lib/date";
+import { todayDateOnly } from "@/lib/date";
 import invariant from "tiny-invariant";
 
 type RefereeAppointment = {
@@ -28,7 +28,7 @@ type Appointment = RefereeAppointment | SetupHelperAppointment;
 
 export type MatchdayAppointment = {
   matchdayId: number;
-  matchdayDate: Date;
+  matchdayDate: string;
   tournamentId: number;
   gameStartTime: string;
   cancelledAt: Date | null;
@@ -47,7 +47,7 @@ export async function getMatchdayAppointmentsByUserId(
     return [];
   }
 
-  const currentDate = getCurrentLocalDateTime().startOf("day").toJSDate();
+  const currentDate = todayDateOnly();
   const appointmentsByMatchday = new Map<number, MatchdayAppointment>();
 
   if (userReferee) {
@@ -123,7 +123,7 @@ export async function getMatchdayAppointmentsByUserId(
     }
   }
 
-  return Array.from(appointmentsByMatchday.values()).sort(
-    (a, b) => a.matchdayDate.getTime() - b.matchdayDate.getTime(),
+  return Array.from(appointmentsByMatchday.values()).sort((a, b) =>
+    a.matchdayDate.localeCompare(b.matchdayDate),
   );
 }


### PR DESCRIPTION
## Problem
Spieler meldeten: „Nicht verfügbare Tage" werden um **einen Tag verschoben** gespeichert und lassen sich **nicht mehr abwählen** (10.12. → 9.12., gesperrte Kalenderzelle). Ursache: JS `Date` ist ein Instant — react-day-picker liefert Browser-Lokal-Mitternacht, Drizzle `date({mode:"date"})` serialisiert mit `toISOString()` (UTC) → Berliner Kalendertage landen auf dem Vortag. `birthDate` hatte denselben Bug; in `pairing.tsx` kaschierte ein `+1 Tag`-HOTFIX das Problem für die Admin-Ansicht.

## Lösung: Zwei-Welten-Regel (evidenzbasiert: Drizzle-Docs/#4593, PostgreSQL-Docs, daypicker.dev)

| Welt | Träger | Helpers (`src/lib/date.ts`) |
|---|---|---|
| **Kalendertag** (matchday, birthDate, notAvailableDays, tournament-Daten) | zonenfreier `'YYYY-MM-DD'`-String, DB-Spalte bleibt `date` | `parseDateOnly` · `formatDateOnly` · `toDateOnly` · `todayDateOnly` · `utcDateToDateOnly` · `isValidDateOnly` |
| **Instant** (createdAt, Spielbeginn, Verlegungen) | UTC-Timestamp, Anzeige `EVENT_TIME_ZONE` (Europe/Berlin) | `toLocalDateTime` · `formatDate` · `formatLongDate` · `formatEventDateTime` |

- 6 Drizzle-Spalten auf `mode:"string"` (kein DDL); alle 3 Kalender-Bindings auf `timeZone="UTC"` + `TZDate`
- Deselect-Bugfix (letzter Tag abwählbar), `+1`-HOTFIX entfernt → String-Vergleich
- Zod-Härtung: `isValidDateOnly` lehnt auch kalendarisch unmögliche Daten (30.02.) ab
- **date-fns-Dependency entfernt**, tote Helpers gelöscht, Taxonomie `parse*`/`format*`/`to*`, Konventionen in `CLAUDE.md`
- **Review-Feedback aus #195 (@not-paul-v) eingebaut:** ELO-Prefill liegt jetzt serverseitig in `page.tsx` (fertige initialValues, 5s-Timeout-Guard) — useEffect, Prop und eslint-disable entfallen

## ✅ Migration 0025 — auf Dev bereits ausgeführt und belegt
Schiebt bestehende `not_available_days` & `birth_date` um **+1 Tag** und dedupliziert (nur Participant-Spalten). Beweis auf Dev: Wochentagsverteilung der 110 Sperrtage vorher **Mo 46 / Mi 34 / Do 30** (0 auf Spieltagen!), nachher **Di 43 / Do 34 / Fr 29** (100 % gültig); betroffener Spieler-Fall exakt auf die gewünschten Tage (29.09. + 10.12.) korrigiert; `matchday.date` stimmt mit `day_of_week` überein (zu Recht nicht migriert).
**⚠️ Prod:** `bunx drizzle-kit migrate` **unmittelbar vor** dem Live-Schalten dieses Codes ausführen (Migration ohne Code: alter Hotfix rechnet +2; Code ohne Migration: Altdaten −1).

## Verifikation
- `tsc` 0 · ESLint **0 Fehler, 0 Warnings** · **79 Tests grün** — Datums-Suite identisch unter Berlin/UTC/New York/Tokio (20 neue Tests: Round-Trip, DST-Übergangstage, Zod-Grenze, Berlin-Tagesgrenze)
- **End-to-End im Browser (Playwright gegen Dev):** alle Anmeldefelder mit DB-Round-Trip (Tage wählen/speichern/reload/abwählen inkl. letztem Tag, Geburtsdatum, Elo-Validierung, Löschen-Dialog); Admin-Paarungen mit Positiv-/Negativ-Kontrolle der roten Markierung; 16-Seiten-Sweep ohne „Invalid DateTime"; DWZ-Report-Download korrekt; serverseitiger HSK-Prefill mit FIDE-Fallback live verifiziert
- **DST geprüft** an den Umstellungstagen 2026 (29.03./25.10.): Round-Trip, 19:30-Spielbeginn (+02→+01 korrekt), Fristende, Picker — alles stabil

## Review (8 Winkel, adversarial verifiziert)
44 Kandidaten → 10 Findings: 1 gefixt (Zod-Kalendervalidität), 1 operativ (Deploy-Reihenfolge, s. o.), 3 pre-existing dokumentiert (weekYear-Pinning bei Turnier-Anlage über Jahreswechsel; fehlende serverseitige Schema-Validierung in createParticipant; FullCalendar-Randfälle für Browser östlich Berlins — verhaltensgleich zu vorher), 5 Qualitäts-Follow-ups (DateOnlyCalendar-Wrapper, currentGameDate als String-Prop, utcDateToDateOnly-Naming, Render-Memos, Spieltag-Regeln aus matchday-Zeilen speisen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)