### PR TITLE
Prefill-Timeout: AbortSignal statt Promise.race-Hack

### DIFF
--- a/src/actions/participant.ts
+++ b/src/actions/participant.ts
@@ -143,6 +143,7 @@ export async function deleteParticipant(
 export async function getParticipantEloData(
   firstName: string,
   lastName: string,
+  signal?: AbortSignal,
 ): Promise<{
   title: string | null;
   nationality: string;
@@ -158,6 +159,7 @@ export async function getParticipantEloData(
 
   const clubData = await fetch(
     "https://www.schachbund.de/php/dewis/verein.php?zps=40023&format=csv",
+    { signal },
   );
   const clubCsv = await clubData.text();
 
@@ -189,6 +191,7 @@ export async function getParticipantEloData(
 
   const playerData = await fetch(
     `https://www.schachbund.de/php/dewis/spieler.php?pkz=${playerId}&format=csv`,
+    { signal },
   );
   const playerCsv = await playerData.text();
 
@@ -204,7 +207,7 @@ export async function getParticipantEloData(
   const dwzRating = parseRating(playerFields[4]);
   const fideId = playerFields[6] || null;
 
-  const fideProfile = fideId ? await getFideProfile(fideId) : null;
+  const fideProfile = fideId ? await getFideProfile(fideId, signal) : null;
 
   return {
     title: fideProfile?.title ?? (playerFields[8] || null),
@@ -221,10 +224,11 @@ export async function getParticipantEloData(
 
 export async function getFideRatingById(
   fideId: string,
+  signal?: AbortSignal,
 ): Promise<number | null> {
   await authWithRedirect();
 
-  const fideProfile = await getFideProfile(fideId);
+  const fideProfile = await getFideProfile(fideId, signal);
   return fideProfile?.fideRating ?? null;
 }
 

--- a/src/app/(setup)/klubturnier-anmeldung/page.tsx
+++ b/src/app/(setup)/klubturnier-anmeldung/page.tsx
@@ -20,29 +20,26 @@ import { getParticipantByProfileIdAndTournamentId } from "@/db/repositories/part
 import { getPromotionEligibility } from "@/services/promotion";
 import { redirect } from "next/navigation";
 
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
-  return Promise.race([
-    promise,
-    new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
-  ]);
-}
+const PREFILL_TIMEOUT_MS = 5000;
 
 async function getPrefillEloData(
   profile: Profile,
   previousParticipant: Participant,
 ): Promise<ParticipantEloPrefill | null> {
+  const signal = AbortSignal.timeout(PREFILL_TIMEOUT_MS);
   try {
-    const eloData = await withTimeout(
-      getParticipantEloData(profile.firstName, profile.lastName),
-      5000,
+    const eloData = await getParticipantEloData(
+      profile.firstName,
+      profile.lastName,
+      signal,
     );
     if (eloData) {
       return eloData;
     }
     if (previousParticipant.fideId) {
-      const fideRating = await withTimeout(
-        getFideRatingById(previousParticipant.fideId),
-        5000,
+      const fideRating = await getFideRatingById(
+        previousParticipant.fideId,
+        signal,
       );
       if (fideRating != null) {
         return { fideRating };

--- a/src/lib/fide/profile.ts
+++ b/src/lib/fide/profile.ts
@@ -20,6 +20,7 @@ export type FideProfile = {
 
 export async function getFideProfile(
   fideId: string,
+  signal?: AbortSignal,
 ): Promise<FideProfile | null> {
   const id = fideId.trim();
   if (!/^\d+$/.test(id)) {
@@ -28,7 +29,9 @@ export async function getFideProfile(
 
   let html: string;
   try {
-    const response = await fetch(`https://ratings.fide.com/profile/${id}`);
+    const response = await fetch(`https://ratings.fide.com/profile/${id}`, {
+      signal,
+    });
     if (!response.ok) {
       return null;
     }


### PR DESCRIPTION
Folge-Fix zu #196 (Review-Feedback).

## Problem
Das serverseitige ELO-Prefill in `klubturnier-anmeldung/page.tsx` schützte den externen HTTP-Call (schachbund.de / ratings.fide.com) mit einem `Promise.race` gegen ein `setTimeout` — ein **Anti-Pattern**:
- **Keine Cancellation:** Nach dem Timeout gewinnt zwar das Race, aber der eigentliche `fetch` läuft im Hintergrund weiter.
- **Timer-Leak:** Das `setTimeout` wird nie geräumt und bleibt bis zum Ablauf hängen, auch wenn der Request längst fertig ist.

## Lösung: Timeout an der I/O-Grenze
Ein optionales `signal?: AbortSignal` wird durch die drei Fetch-Funktionen bis zu den `fetch`-Aufrufen gefädelt:
- `getParticipantEloData(..., signal?)` → beide schachbund-Fetches + `getFideProfile`
- `getFideRatingById(..., signal?)` → `getFideProfile`
- `getFideProfile(..., signal?)` → `fetch(..., { signal })`

Die Server-Komponente vergibt **ein** `AbortSignal.timeout(5s)` für den gesamten Prefill. Bei Timeout wird der Request **tatsächlich abgebrochen** und graceful zu `null` degradiert (Nutzer trägt manuell ein). Kein Race, kein `setTimeout`, kein dangling Timer.

**Kein Verhaltenswechsel für andere Aufrufer:** Client (`fetchAndApplyEloData`) und Admin-Batch (`updateAllParticipantRatings`) übergeben kein Signal → `fetch(url, { signal: undefined })` ≡ `fetch(url)`.

## Verifikation
- `tsc` 0 · ESLint 0
- Runtime: `AbortSignal.timeout(1)` → sofortiges `null` in 8 ms (Request abgebrochen, kein Hängen); `AbortSignal.timeout(8s)` → echte FIDE-Daten (Carlsen 2823) in 273 ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)