### PR TITLE
fix: doppelte Wochentage in der Anmeldung (bevorzugter == sekundärer Spieltag)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.tabSize": 2,
-  "css.lint.unknownAtRules": "ignore"
+  "css.lint.unknownAtRules": "ignore",
+  "biome.enabled": false
 }

--- a/drizzle/0026_robust_paibok.sql
+++ b/drizzle/0026_robust_paibok.sql
@@ -1,0 +1,18 @@
+-- Data cleanup: drop the preferred match day from the secondary match days so the
+-- CHECK constraints below can be added. Runs first, otherwise ADD CONSTRAINT fails
+-- on existing rows where preferred and secondary overlap.
+UPDATE "participant"
+SET "secondary_match_days" = array_remove("secondary_match_days", "preferred_match_day")
+WHERE "preferred_match_day" = ANY("secondary_match_days");
+--> statement-breakpoint
+UPDATE "referee"
+SET "secondary_match_day" = array_remove("secondary_match_day", "preferred_match_day")
+WHERE "preferred_match_day" = ANY("secondary_match_day");
+--> statement-breakpoint
+UPDATE "setup_helper"
+SET "secondary_match_day" = array_remove("secondary_match_day", "preferred_match_day")
+WHERE "preferred_match_day" = ANY("secondary_match_day");
+--> statement-breakpoint
+ALTER TABLE "participant" ADD CONSTRAINT "participant_secondary_match_days_no_preferred" CHECK (NOT ("participant"."preferred_match_day" = ANY("participant"."secondary_match_days")));--> statement-breakpoint
+ALTER TABLE "referee" ADD CONSTRAINT "referee_secondary_match_days_no_preferred" CHECK (NOT ("referee"."preferred_match_day" = ANY("referee"."secondary_match_day")));--> statement-breakpoint
+ALTER TABLE "setup_helper" ADD CONSTRAINT "setup_helper_secondary_match_days_no_preferred" CHECK (NOT ("setup_helper"."preferred_match_day" = ANY("setup_helper"."secondary_match_day")));

--- a/drizzle/meta/0026_snapshot.json
+++ b/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,1913 @@
+{
+  "id": "980711d1-a3d9-48db-ae49-388ffdae3468",
+  "prevId": "2d43a21b-6a39-4c32-a150-830ff93d69a5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "white_player_id": {
+          "name": "white_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "black_player_id": {
+          "name": "black_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pgn_id": {
+          "name": "pgn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_number": {
+          "name": "board_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_postponement": {
+      "name": "game_postponement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_postponement_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponing_participant_id": {
+          "name": "postponing_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponed_by_profile_id": {
+          "name": "postponed_by_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group": {
+      "name": "group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "group_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_tournament_id_group_number_pk": {
+          "name": "group_tournament_id_group_number_pk",
+          "columns": [
+            "tournament_id",
+            "group_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.juror": {
+      "name": "juror",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "juror_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "juror_tournament_id_profile_id_unique": {
+          "name": "juror_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday": {
+      "name": "matchday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "matchday_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_week_id": {
+          "name": "tournament_week_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_needed": {
+          "name": "referee_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_game": {
+      "name": "matchday_game",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_game_matchday_id_game_id_pk": {
+          "name": "matchday_game_matchday_id_game_id_pk",
+          "columns": [
+            "matchday_id",
+            "game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_referee": {
+      "name": "matchday_referee",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_id": {
+          "name": "referee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_referee_matchday_id_referee_id_pk": {
+          "name": "matchday_referee_matchday_id_referee_id_pk",
+          "columns": [
+            "matchday_id",
+            "referee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_setup_helper": {
+      "name": "matchday_setup_helper",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_helper_id": {
+          "name": "setup_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_setup_helper_matchday_id_setup_helper_id_pk": {
+          "name": "matchday_setup_helper_matchday_id_setup_helper_id_pk",
+          "columns": [
+            "matchday_id",
+            "setup_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_match_entering_helper": {
+      "name": "group_match_entering_helper",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_entering_helper_id": {
+          "name": "match_entering_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_match_entering_helper_group_id_match_entering_helper_id_pk": {
+          "name": "group_match_entering_helper_group_id_match_entering_helper_id_pk",
+          "columns": [
+            "group_id",
+            "match_entering_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_entering_helper": {
+      "name": "match_entering_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "match_entering_helper_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_groups_to_enter": {
+          "name": "number_of_groups_to_enter",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_entering_helper_tournament_id_profile_id_unique": {
+          "name": "match_entering_helper_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant": {
+      "name": "participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "participant_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chess_club": {
+          "name": "chess_club",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'m'"
+        },
+        "dwz_rating": {
+          "name": "dwz_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_rating": {
+          "name": "fide_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_club_id": {
+          "name": "zps_club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_player_id": {
+          "name": "zps_player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_days": {
+          "name": "secondary_match_days",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "not_available_days": {
+          "name": "not_available_days",
+          "type": "date[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_fee_payed": {
+          "name": "entry_fee_payed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exercise_promotion_right": {
+          "name": "exercise_promotion_right",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participant_tournament_id_profile_id_unique": {
+          "name": "participant_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "participant_secondary_match_days_no_preferred": {
+          "name": "participant_secondary_match_days_no_preferred",
+          "value": "NOT (\"participant\".\"preferred_match_day\" = ANY(\"participant\".\"secondary_match_days\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.participant_group": {
+      "name": "participant_group",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_position": {
+          "name": "group_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "participant_group_group_id_participant_id_group_position_pk": {
+          "name": "participant_group_group_id_participant_id_group_position_pk",
+          "columns": [
+            "group_id",
+            "participant_id",
+            "group_position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pgn": {
+      "name": "pgn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pgn_game_id_unique": {
+          "name": "pgn_game_id_unique",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pgn_game_id_game_id_fk": {
+          "name": "pgn_game_id_game_id_fk",
+          "tableFrom": "pgn",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "profile_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_title": {
+          "name": "academic_title",
+          "type": "academic_title",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_email_unique": {
+          "name": "profile_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referee": {
+      "name": "referee",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "referee_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "referee_tournament_id_profile_id_unique": {
+          "name": "referee_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "referee_secondary_match_days_no_preferred": {
+          "name": "referee_secondary_match_days_no_preferred",
+          "value": "NOT (\"referee\".\"preferred_match_day\" = ANY(\"referee\".\"secondary_match_day\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.setup_helper": {
+      "name": "setup_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "setup_helper_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "setup_helper_tournament_id_profile_id_unique": {
+          "name": "setup_helper_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "setup_helper_secondary_match_days_no_preferred": {
+          "name": "setup_helper_secondary_match_days_no_preferred",
+          "value": "NOT (\"setup_helper\".\"preferred_match_day\" = ANY(\"setup_helper\".\"secondary_match_day\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tournament": {
+      "name": "tournament",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_rounds": {
+          "name": "number_of_rounds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_registration_date": {
+          "name": "end_registration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_announcement_offset_days": {
+          "name": "group_announcement_offset_days",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_limit": {
+          "name": "time_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_clocks_digital": {
+          "name": "all_clocks_digital",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tie_break_method": {
+          "name": "tie_break_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "software": {
+          "name": "software",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "tournament_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registration'"
+        },
+        "game_start_time": {
+          "name": "game_start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'19:00:00'"
+        },
+        "organizer_profile_id": {
+          "name": "organizer_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "one_tournament_in_registration": {
+          "name": "one_tournament_in_registration",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tournament\".\"stage\" = 'registration'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_slug_unique": {
+          "name": "tournament_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_week": {
+      "name": "tournament_week",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_week_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_week_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "week_number": {
+          "name": "week_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainer": {
+      "name": "trainer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "trainer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trainer_tournament_id_profile_id_unique": {
+          "name": "trainer_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.academic_title": {
+      "name": "academic_title",
+      "schema": "public",
+      "values": [
+        "Dr."
+      ]
+    },
+    "public.result": {
+      "name": "result",
+      "schema": "public",
+      "values": [
+        "1:0",
+        "0:1",
+        "½-½",
+        "+:-",
+        "-:+",
+        "-:-",
+        "0-½",
+        "½-0"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "m",
+        "f"
+      ]
+    },
+    "public.match_day": {
+      "name": "match_day",
+      "schema": "public",
+      "values": [
+        "tuesday",
+        "thursday",
+        "friday"
+      ]
+    },
+    "public.tournament_stage": {
+      "name": "tournament_stage",
+      "schema": "public",
+      "values": [
+        "registration",
+        "running",
+        "done"
+      ]
+    },
+    "public.tournament_week_status": {
+      "name": "tournament_week_status",
+      "schema": "public",
+      "values": [
+        "regular",
+        "catch-up"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1783015072822,
       "tag": "0025_fix_date_only_tz_shift",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1783460140509,
+      "tag": "0026_robust_paibok",
+      "breakpoints": true
     }
   ]
 }

--- a/src/actions/participant.ts
+++ b/src/actions/participant.ts
@@ -19,6 +19,7 @@ import {
 } from "@/constants/constants";
 import { revalidatePath, unstable_cache } from "next/cache";
 import { action } from "@/lib/actions";
+import { hasSecondaryMatchDayConflict } from "@/lib/match-days";
 import { parseDateOnly } from "@/lib/date";
 import { getFideProfile } from "@/lib/fide/profile";
 
@@ -58,10 +59,18 @@ function parseRating(value: string | undefined): number | null {
   return Number.isFinite(rating) && rating > 0 ? rating : null;
 }
 
-export async function createParticipant(
+export const createParticipant = action(async (
   tournamentId: number,
   data: z.infer<typeof participantFormSchema>,
-) {
+) => {
+  invariant(
+    !hasSecondaryMatchDayConflict(
+      data.preferredMatchDay,
+      data.secondaryMatchDays,
+    ),
+    "Preferred match day cannot also be a secondary match day",
+  );
+
   const session = await authWithRedirect();
 
   let chessClub: string;
@@ -138,7 +147,7 @@ export async function createParticipant(
         exercisePromotionRight,
       },
     });
-}
+});
 
 export async function deleteParticipant(
   tournamentId: number,

--- a/src/actions/referee.ts
+++ b/src/actions/referee.ts
@@ -8,12 +8,22 @@ import { refereeFormSchema } from "@/schema/referee";
 import { getProfileByUserId } from "@/db/repositories/profile";
 import { getTournamentById } from "@/db/repositories/tournament";
 import { authWithRedirect } from "@/auth/utils";
+import { action } from "@/lib/actions";
+import { hasSecondaryMatchDayConflict } from "@/lib/match-days";
 import { and, eq } from "drizzle-orm";
 
-export async function createReferee(
+export const createReferee = action(async (
   tournamentId: number,
   data: z.infer<typeof refereeFormSchema>,
-) {
+) => {
+  invariant(
+    !hasSecondaryMatchDayConflict(
+      data.preferredMatchDay,
+      data.secondaryMatchDays,
+    ),
+    "Preferred match day cannot also be a secondary match day",
+  );
+
   const session = await authWithRedirect();
 
   const tournament = await getTournamentById(tournamentId);
@@ -42,7 +52,7 @@ export async function createReferee(
         fideId: data.fideId,
       },
     });
-}
+});
 
 export async function deleteReferee(tournamentId: number, refereeId: number) {
   const session = await authWithRedirect();

--- a/src/actions/setup-helper.ts
+++ b/src/actions/setup-helper.ts
@@ -8,12 +8,22 @@ import { setupHelper } from "@/db/schema/setupHelper";
 import { getProfileByUserId } from "@/db/repositories/profile";
 import { getTournamentById } from "@/db/repositories/tournament";
 import { authWithRedirect } from "@/auth/utils";
+import { action } from "@/lib/actions";
+import { hasSecondaryMatchDayConflict } from "@/lib/match-days";
 import { and, eq } from "drizzle-orm";
 
-export async function createSetupHelper(
+export const createSetupHelper = action(async (
   tournamentId: number,
   data: z.infer<typeof setupHelperFormSchema>,
-) {
+) => {
+  invariant(
+    !hasSecondaryMatchDayConflict(
+      data.preferredMatchDay,
+      data.secondaryMatchDays,
+    ),
+    "Preferred match day cannot also be a secondary match day",
+  );
+
   const session = await authWithRedirect();
 
   const tournament = await getTournamentById(tournamentId);
@@ -40,7 +50,8 @@ export async function createSetupHelper(
         secondaryMatchDays: data.secondaryMatchDays,
       },
     });
-}
+});
+
 export async function deleteSetupHelper(
   tournamentId: number,
   setupHelperId: number,

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -36,6 +36,8 @@ import {
   DialogTrigger,
 } from "../../ui/dialog";
 import { participantFormSchema } from "@/schema/participant";
+import { removePreferredFromSecondary } from "@/lib/match-days";
+import { DayOfWeek } from "@/db/types/group";
 import { MatchDaysCheckboxes } from "./matchday-selection";
 import { CountryDropdown } from "@/components/ui/country-dropdown";
 import { cn } from "@/lib/utils";
@@ -174,6 +176,14 @@ export function ParticipateForm({
         );
       }
     });
+  };
+
+  const handlePreferredMatchDayChange = (value: DayOfWeek) => {
+    form.setValue("preferredMatchDay", value);
+    form.setValue(
+      "secondaryMatchDays",
+      removePreferredFromSecondary(value, form.getValues("secondaryMatchDays")),
+    );
   };
 
   const handleChessClubTypeChange = (value: "hsk" | "other" | "vereinslos") => {
@@ -557,7 +567,10 @@ export function ParticipateForm({
             <FormItem>
               <FormLabel required>Bevorzugter Spieltag</FormLabel>
               <FormControl>
-                <Select value={field.value} onValueChange={field.onChange}>
+                <Select
+                  value={field.value}
+                  onValueChange={handlePreferredMatchDayChange}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Wähle einen Spieltag" />
                   </SelectTrigger>

--- a/src/components/klubturnier-anmeldung/forms/referee-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/referee-form.tsx
@@ -24,6 +24,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import z from "zod";
 import { useTransition } from "react";
 import { MatchDaysCheckboxes } from "./matchday-selection";
+import { removePreferredFromSecondary } from "@/lib/match-days";
+import { DayOfWeek } from "@/db/types/group";
 
 import { Info, Shield, Users } from "lucide-react";
 import { TournamentStage } from "@/db/types/tournament";
@@ -52,6 +54,14 @@ export function RefereeForm({
   });
 
   const preferredMatchDay = form.watch("preferredMatchDay");
+
+  const handlePreferredMatchDayChange = (value: DayOfWeek) => {
+    form.setValue("preferredMatchDay", value);
+    form.setValue(
+      "secondaryMatchDays",
+      removePreferredFromSecondary(value, form.getValues("secondaryMatchDays")),
+    );
+  };
 
   const handleFormSubmit = (data: z.infer<typeof refereeFormSchema>) => {
     startTransition(async () => {
@@ -108,7 +118,10 @@ export function RefereeForm({
               <FormItem className="flex-1">
                 <FormLabel required>Bevorzugter Spieltag</FormLabel>
                 <FormControl>
-                  <Select value={field.value} onValueChange={field.onChange}>
+                  <Select
+                    value={field.value}
+                    onValueChange={handlePreferredMatchDayChange}
+                  >
                     <SelectTrigger>
                       <SelectValue placeholder="Wähle einen Spieltag" />
                     </SelectTrigger>

--- a/src/components/klubturnier-anmeldung/forms/setup-helper-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/setup-helper-form.tsx
@@ -23,6 +23,8 @@ import z from "zod";
 import { useTransition } from "react";
 import { MatchDaysCheckboxes } from "./matchday-selection";
 import { setupHelperFormSchema } from "@/schema/setupHelper";
+import { removePreferredFromSecondary } from "@/lib/match-days";
+import { DayOfWeek } from "@/db/types/group";
 
 import { Info, Users, Wrench } from "lucide-react";
 import { TournamentStage } from "@/db/types/tournament";
@@ -49,6 +51,14 @@ export function SetupHelperForm({
   });
 
   const preferredMatchDay = form.watch("preferredMatchDay");
+
+  const handlePreferredMatchDayChange = (value: DayOfWeek) => {
+    form.setValue("preferredMatchDay", value);
+    form.setValue(
+      "secondaryMatchDays",
+      removePreferredFromSecondary(value, form.getValues("secondaryMatchDays")),
+    );
+  };
 
   const handleFormSubmit = (data: z.infer<typeof setupHelperFormSchema>) => {
     startTransition(async () => {
@@ -104,7 +114,10 @@ export function SetupHelperForm({
             <FormItem>
               <FormLabel required>Bevorzugter Spieltag</FormLabel>
               <FormControl>
-                <Select value={field.value} onValueChange={field.onChange}>
+                <Select
+                  value={field.value}
+                  onValueChange={handlePreferredMatchDayChange}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Wähle einen Spieltag" />
                   </SelectTrigger>

--- a/src/components/klubturnier-anmeldung/roles-manager.tsx
+++ b/src/components/klubturnier-anmeldung/roles-manager.tsx
@@ -40,6 +40,8 @@ import {
 import { createReferee, deleteReferee } from "@/actions/referee";
 import { Participant } from "@/db/types/participant";
 import type { PromotionEligibility } from "@/services/promotion";
+import { isError } from "@/lib/actions";
+import { toast } from "sonner";
 
 export type ParticipantEloPrefill = Partial<
   NonNullable<Awaited<ReturnType<typeof getParticipantEloData>>>
@@ -77,7 +79,11 @@ export function RolesManager({
   const handleParticipateFormSubmit = async (
     data: z.infer<typeof participantFormSchema>,
   ) => {
-    await createParticipant(tournament.id, data);
+    const result = await createParticipant(tournament.id, data);
+    if (isError(result)) {
+      toast.error("Deine Anmeldung konnte nicht gespeichert werden.");
+      return;
+    }
     router.refresh();
   };
 
@@ -91,7 +97,11 @@ export function RolesManager({
   const handleRefereeFormSubmit = async (
     data: z.infer<typeof refereeFormSchema>,
   ) => {
-    await createReferee(tournament.id, data);
+    const result = await createReferee(tournament.id, data);
+    if (isError(result)) {
+      toast.error("Deine Anmeldung konnte nicht gespeichert werden.");
+      return;
+    }
     router.refresh();
   };
 
@@ -121,7 +131,11 @@ export function RolesManager({
   const handleSetupHelperFormSubmit = async (
     data: z.infer<typeof setupHelperFormSchema>,
   ) => {
-    await createSetupHelper(tournament.id, data);
+    const result = await createSetupHelper(tournament.id, data);
+    if (isError(result)) {
+      toast.error("Deine Anmeldung konnte nicht gespeichert werden.");
+      return;
+    }
     router.refresh();
   };
 

--- a/src/db/schema/participant.ts
+++ b/src/db/schema/participant.ts
@@ -1,6 +1,7 @@
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import {
   boolean,
+  check,
   integer,
   pgTable,
   text,
@@ -42,7 +43,13 @@ export const participant = pgTable(
 
     ...timestamps,
   },
-  (table) => [unique().on(table.tournamentId, table.profileId)],
+  (table) => [
+    unique().on(table.tournamentId, table.profileId),
+    check(
+      "participant_secondary_match_days_no_preferred",
+      sql`NOT (${table.preferredMatchDay} = ANY(${table.secondaryMatchDays}))`,
+    ),
+  ],
 );
 
 export const participantRelations = relations(participant, ({ one }) => ({

--- a/src/db/schema/referee.ts
+++ b/src/db/schema/referee.ts
@@ -1,5 +1,5 @@
-import { relations } from "drizzle-orm";
-import { integer, pgTable, text, unique } from "drizzle-orm/pg-core";
+import { relations, sql } from "drizzle-orm";
+import { check, integer, pgTable, text, unique } from "drizzle-orm/pg-core";
 import { profile } from "./profile";
 import { tournament } from "./tournament";
 import { matchDay, timestamps } from "./columns.helpers";
@@ -19,7 +19,13 @@ export const referee = pgTable(
 
     ...timestamps,
   },
-  (table) => [unique().on(table.tournamentId, table.profileId)],
+  (table) => [
+    unique().on(table.tournamentId, table.profileId),
+    check(
+      "referee_secondary_match_days_no_preferred",
+      sql`NOT (${table.preferredMatchDay} = ANY(${table.secondaryMatchDays}))`,
+    ),
+  ],
 );
 
 export const refereeRelations = relations(referee, ({ one }) => ({

--- a/src/db/schema/setupHelper.ts
+++ b/src/db/schema/setupHelper.ts
@@ -1,5 +1,5 @@
-import { relations } from "drizzle-orm";
-import { integer, pgTable, unique } from "drizzle-orm/pg-core";
+import { relations, sql } from "drizzle-orm";
+import { check, integer, pgTable, unique } from "drizzle-orm/pg-core";
 import { profile } from "./profile";
 import { tournament } from "./tournament";
 import { matchDay, timestamps } from "./columns.helpers";
@@ -17,7 +17,13 @@ export const setupHelper = pgTable(
 
     ...timestamps,
   },
-  (table) => [unique().on(table.tournamentId, table.profileId)],
+  (table) => [
+    unique().on(table.tournamentId, table.profileId),
+    check(
+      "setup_helper_secondary_match_days_no_preferred",
+      sql`NOT (${table.preferredMatchDay} = ANY(${table.secondaryMatchDays}))`,
+    ),
+  ],
 );
 
 export const setupHelperRelations = relations(setupHelper, ({ one }) => ({

--- a/src/lib/match-days.ts
+++ b/src/lib/match-days.ts
@@ -1,0 +1,15 @@
+import { DayOfWeek } from "@/db/types/group";
+
+export function hasSecondaryMatchDayConflict(
+  preferredMatchDay: DayOfWeek,
+  secondaryMatchDays: DayOfWeek[],
+): boolean {
+  return secondaryMatchDays.includes(preferredMatchDay);
+}
+
+export function removePreferredFromSecondary(
+  preferredMatchDay: DayOfWeek,
+  secondaryMatchDays: DayOfWeek[],
+): DayOfWeek[] {
+  return secondaryMatchDays.filter((day) => day !== preferredMatchDay);
+}

--- a/src/schema/participant.ts
+++ b/src/schema/participant.ts
@@ -1,5 +1,6 @@
 import { CLUBLESS_KEY, DEFAULT_CLUB_KEY } from "@/constants/constants";
 import { availableMatchDays } from "@/db/schema/columns.helpers";
+import { hasSecondaryMatchDayConflict } from "@/lib/match-days";
 import {
   getCurrentLocalDateTime,
   isValidDateOnly,
@@ -138,5 +139,17 @@ export const participantFormSchema = z
     {
       message: "Geschlecht ist für vereinslose Spieler erforderlich",
       path: ["gender"],
+    },
+  )
+  .refine(
+    (data) =>
+      !hasSecondaryMatchDayConflict(
+        data.preferredMatchDay,
+        data.secondaryMatchDays,
+      ),
+    {
+      message:
+        "Ein Wochentag kann nicht gleichzeitig bevorzugter und alternativer Spieltag sein.",
+      path: ["secondaryMatchDays"],
     },
   );

--- a/src/schema/referee.ts
+++ b/src/schema/referee.ts
@@ -1,10 +1,24 @@
 import { availableMatchDays } from "@/db/schema/columns.helpers";
+import { hasSecondaryMatchDayConflict } from "@/lib/match-days";
 import z from "zod";
 
-export const refereeFormSchema = z.object({
-  preferredMatchDay: z.enum(availableMatchDays, {
-    errorMap: () => ({ message: "Bevorzugter Spieltag ist erforderlich" }),
-  }),
-  secondaryMatchDays: z.array(z.enum(availableMatchDays)),
-  fideId: z.string().min(1, "FIDE ID ist erforderlich"),
-});
+export const refereeFormSchema = z
+  .object({
+    preferredMatchDay: z.enum(availableMatchDays, {
+      errorMap: () => ({ message: "Bevorzugter Spieltag ist erforderlich" }),
+    }),
+    secondaryMatchDays: z.array(z.enum(availableMatchDays)),
+    fideId: z.string().min(1, "FIDE ID ist erforderlich"),
+  })
+  .refine(
+    (data) =>
+      !hasSecondaryMatchDayConflict(
+        data.preferredMatchDay,
+        data.secondaryMatchDays,
+      ),
+    {
+      message:
+        "Ein Wochentag kann nicht gleichzeitig bevorzugter und alternativer Spieltag sein.",
+      path: ["secondaryMatchDays"],
+    },
+  );

--- a/src/schema/setupHelper.ts
+++ b/src/schema/setupHelper.ts
@@ -1,9 +1,23 @@
 import { availableMatchDays } from "@/db/schema/columns.helpers";
+import { hasSecondaryMatchDayConflict } from "@/lib/match-days";
 import z from "zod";
 
-export const setupHelperFormSchema = z.object({
-  preferredMatchDay: z.enum(availableMatchDays, {
-    errorMap: () => ({ message: "Bevorzugter Spieltag ist erforderlich" }),
-  }),
-  secondaryMatchDays: z.array(z.enum(availableMatchDays)),
-});
+export const setupHelperFormSchema = z
+  .object({
+    preferredMatchDay: z.enum(availableMatchDays, {
+      errorMap: () => ({ message: "Bevorzugter Spieltag ist erforderlich" }),
+    }),
+    secondaryMatchDays: z.array(z.enum(availableMatchDays)),
+  })
+  .refine(
+    (data) =>
+      !hasSecondaryMatchDayConflict(
+        data.preferredMatchDay,
+        data.secondaryMatchDays,
+      ),
+    {
+      message:
+        "Ein Wochentag kann nicht gleichzeitig bevorzugter und alternativer Spieltag sein.",
+      path: ["secondaryMatchDays"],
+    },
+  );


### PR DESCRIPTION
## Problem
In der Gruppenverwaltung tauchten bei einigen Anmeldungen (z.B. Malte Schacht) **Duplikate in den Wochentagen** auf: der bevorzugte Spieltag war identisch mit einem der sekundären. Laut UI sollte das unmöglich sein – die Checkboxen in `matchday-selection.tsx` blenden den bevorzugten Tag ja aus.

**Ursache:** Das Ausblenden verhindert nur das *Ankreuzen* des bevorzugten Tags. Wählt man aber erst einen Tag als sekundär (z.B. Di.) und ändert *danach* den bevorzugten Tag auf genau diesen (Di.), bleibt er im `secondaryMatchDays`-Array stehen – die Checkbox ist nun ausgeblendet und lässt sich nicht mehr abwählen. Beim Speichern landet der Tag doppelt in der DB (primäres + sekundäres Badge in `user-weekday-display.tsx`). Weder `participantFormSchema` noch die Server-Action prüften auf die Überschneidung. Derselbe Fehler steckte in allen drei Rollen (Spieler, Schiedsrichter, Aufbauhelfer).

## Lösung (Defense in Depth)

| Ebene | Änderung |
|---|---|
| **Client-Fix** | Beim Wechsel des bevorzugten Tags wird dieser aus den sekundären Tagen entfernt (`handlePreferredMatchDayChange` → `form.setValue`, analog zu `handleChessClubTypeChange`). Behebt den eigentlichen Bug. |
| **Client-Validierung** | Zod-`refine` in allen drei Schemas zeigt bei Überschneidung eine `FormMessage` am Feld. |
| **DB-seitige Validierung** | Neuer `CHECK`-Constraint pro Tabelle (`participant`, `referee`, `setup_helper`): `NOT (preferred = ANY(secondary))`. |
| **Fehler-Toast** | Die drei Create-Actions laufen jetzt über den `action()`-Wrapper; `roles-manager` prüft `isError` und zeigt einen Toast, statt fehlzuschlagen. |

### Prod-Datenbereinigung
Migration `0026` entfernt zuerst per `array_remove(secondary, preferred)` die doppelten sekundären Tage aus bestehenden Datensätzen – sonst würde `ADD CONSTRAINT` an den Altdaten scheitern – und legt anschließend die Constraints an.

## Geteilte Helper
`src/lib/match-days.ts`: `hasSecondaryMatchDayConflict` / `removePreferredFromSecondary` (wiederverwendet in Forms, Schemas, Actions; `DayOfWeek`-Typ wiederverwendet).

## Test
- `bunx tsc --noEmit` ✓, `eslint` ✓, `vitest` (participant + group-distribution) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)