### PR TITLE
fix(anmeldung): DSB Auto-Übernahme scopen, Rollen-Formulare vereinheitlichen

### DIFF
--- a/src/components/klubturnier-anmeldung/forms/dwz-player-select.tsx
+++ b/src/components/klubturnier-anmeldung/forms/dwz-player-select.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState, type MouseEvent } from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { Paperclip, Search } from "lucide-react";
 import {
   Command,
   CommandEmpty,
-  CommandInput,
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
@@ -19,7 +20,6 @@ type Props = {
   firstName: string;
   lastName: string;
   vkz?: string | null;
-  disabled?: boolean;
   autoApply?: boolean;
   onSelect: (candidate: DsbPlayerCandidate) => void;
 };
@@ -28,22 +28,53 @@ export function DwzPlayerSelect({
   firstName,
   lastName,
   vkz,
-  disabled,
   autoApply,
   onSelect,
 }: Props) {
+  const [initialSearch] = useState(() => ({
+    firstName,
+    lastName,
+    vkz,
+    autoApply,
+    onSelect,
+  }));
   const [query, setQuery] = useState(`${firstName} ${lastName}`.trim());
   const [candidates, setCandidates] = useState<DsbPlayerCandidate[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
-  const [needsManualChoice, setNeedsManualChoice] = useState(false);
-  const hasAutoApplied = useRef(false);
+  const [isLinked, setIsLinked] = useState(false);
 
   const debouncedQuery = useDebouncedValue(query, SEARCH_DEBOUNCE_MS);
 
   useEffect(() => {
-    const shouldAutoApply = Boolean(autoApply) && !hasAutoApplied.current;
-    if (!isFocused && !shouldAutoApply) {
+    if (!initialSearch.autoApply) {
+      return;
+    }
+
+    const { searchFirstName, searchLastName } = splitName(
+      `${initialSearch.firstName} ${initialSearch.lastName}`.trim(),
+    );
+    if (searchLastName.length === 0) {
+      return;
+    }
+
+    let active = true;
+    searchDsbPlayers(searchFirstName, searchLastName, initialSearch.vkz).then(
+      (results) => {
+        if (active && results.length === 1) {
+          initialSearch.onSelect(results[0]);
+          setIsLinked(true);
+        }
+      },
+    );
+
+    return () => {
+      active = false;
+    };
+  }, [initialSearch]);
+
+  useEffect(() => {
+    if (!isFocused) {
       return;
     }
 
@@ -58,17 +89,8 @@ export function DwzPlayerSelect({
     setIsLoading(true);
     searchDsbPlayers(searchFirstName, searchLastName, vkz)
       .then((results) => {
-        if (!active) {
-          return;
-        }
-        setCandidates(results);
-        if (shouldAutoApply) {
-          if (results.length === 1) {
-            hasAutoApplied.current = true;
-            onSelect(results[0]);
-          } else {
-            setNeedsManualChoice(results.length > 1);
-          }
+        if (active) {
+          setCandidates(results);
         }
       })
       .finally(() => {
@@ -80,33 +102,40 @@ export function DwzPlayerSelect({
     return () => {
       active = false;
     };
-  }, [debouncedQuery, isFocused, autoApply, vkz, onSelect]);
+  }, [debouncedQuery, isFocused, vkz]);
+
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const keepInputFocusedOnSelect = (event: MouseEvent) =>
     event.preventDefault();
 
   const handleSelect = (candidate: DsbPlayerCandidate) => {
-    hasAutoApplied.current = true;
-    setNeedsManualChoice(false);
     onSelect(candidate);
+    setIsLinked(true);
+    inputRef.current?.blur();
   };
 
   return (
     <Command shouldFilter={false} className="rounded-md border">
-      <CommandInput
-        placeholder="Vor- und Nachname eingeben…"
-        value={query}
-        onValueChange={setQuery}
-        disabled={disabled}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
-      />
-      {needsManualChoice && !isLoading ? (
-        <p className="border-b px-3 py-2 text-xs text-muted-foreground">
-          Mehrere Einträge zu diesem Namen – bitte den passenden auswählen.
-        </p>
-      ) : null}
-      {isFocused || needsManualChoice ? (
+      <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+        <CommandPrimitive.Input
+          ref={inputRef}
+          placeholder="Vor- und Nachname eingeben…"
+          value={query}
+          onValueChange={(value) => {
+            setIsLinked(false);
+            setQuery(value);
+          }}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          className="flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        />
+        {isLinked ? (
+          <Paperclip className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        ) : null}
+        <Search className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+      </div>
+      {isFocused ? (
         <CommandList onMouseDown={keepInputFocusedOnSelect}>
           {isLoading ? (
             <div className="space-y-1 p-1">
@@ -122,7 +151,7 @@ export function DwzPlayerSelect({
                   key={candidate.nuLigaPersonId}
                   value={candidate.nuLigaPersonId}
                   onSelect={() => handleSelect(candidate)}
-                  className="items-start px-3 py-2.5"
+                  className="items-start px-3 py-2.5 data-[selected=true]:bg-secondary data-[selected=true]:text-secondary-foreground"
                 >
                   <div className="min-w-0 space-y-1">
                     <p className="truncate text-sm font-medium">
@@ -153,8 +182,8 @@ export function DwzPlayerSelect({
 function CandidateSkeleton() {
   return (
     <div className="space-y-2 rounded-sm px-3 py-2.5">
-      <Skeleton className="h-3.5 w-2/3" />
-      <Skeleton className="h-2.5 w-1/2" />
+      <Skeleton className="h-3.5 w-2/3 bg-foreground/10" />
+      <Skeleton className="h-2.5 w-1/2 bg-foreground/10" />
     </div>
   );
 }

--- a/src/components/klubturnier-anmeldung/forms/juror-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/juror-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useForm } from "react-hook-form";
-import { Button } from "@/components/ui/button";
 import {
   Form,
   FormControl,
@@ -12,6 +11,7 @@ import {
 } from "@/components/ui/form";
 import { useTransition } from "react";
 import { jurorFormSchema } from "@/schema/juror";
+import { RoleFormActions } from "./role-form-actions";
 import { zodResolver } from "@hookform/resolvers/zod";
 import z from "zod";
 import { Switch } from "@/components/ui/switch";
@@ -106,26 +106,15 @@ export function JurorForm({
             </FormItem>
           )}
         />
-        <div className="flex items-center gap-2">
-          <Button
-            disabled={isPending}
-            type="submit"
-            className="w-full sm:w-auto"
-          >
-            Antwort speichern
-          </Button>
-          {initiallyParticipating !== undefined &&
-          tournamentStage === "registration" ? (
-            <Button
-              disabled={isPending}
-              onClick={handleDelete}
-              className="w-full sm:w-auto "
-              variant={"outline"}
-            >
-              Änderungen verwerfen
-            </Button>
-          ) : null}
-        </div>
+        <RoleFormActions
+          isPending={isPending}
+          onDelete={
+            initiallyParticipating !== undefined &&
+            tournamentStage === "registration"
+              ? handleDelete
+              : undefined
+          }
+        />
       </form>
     </Form>
   );

--- a/src/components/klubturnier-anmeldung/forms/match-entering-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/match-entering-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useForm } from "react-hook-form";
-import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -22,6 +21,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import z from "zod";
 import { useTransition } from "react";
 import { matchEnteringHelperFormSchema } from "@/schema/matchEnteringHelper";
+import { RoleFormActions } from "./role-form-actions";
 import { ClipboardEdit, Info, Users } from "lucide-react";
 import { TournamentStage } from "@/db/types/tournament";
 
@@ -132,25 +132,14 @@ export function MatchEnteringForm({
           )}
         />
 
-        <div className="flex items-center gap-2">
-          <Button
-            disabled={isPending}
-            type="submit"
-            className="w-full sm:w-auto"
-          >
-            Änderungen speichern
-          </Button>
-          {initialValues !== undefined && tournamentStage === "registration" ? (
-            <Button
-              disabled={isPending}
-              onClick={handleDelete}
-              className="w-full sm:w-auto "
-              variant={"outline"}
-            >
-              Änderungen verwerfen
-            </Button>
-          ) : null}
-        </div>
+        <RoleFormActions
+          isPending={isPending}
+          onDelete={
+            initialValues !== undefined && tournamentStage === "registration"
+              ? handleDelete
+              : undefined
+          }
+        />
       </form>
     </Form>
   );

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useState, useTransition } from "react";
+import { useCallback, useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { TZDate } from "react-day-picker";
 import { CalendarIcon } from "lucide-react";
@@ -26,15 +26,6 @@ import {
 import { Button } from "../../ui/button";
 import { Calendar } from "../../ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "../../ui/popover";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "../../ui/dialog";
 import { participantFormSchema } from "@/schema/participant";
 import { removePreferredFromSecondary } from "@/lib/match-days";
 import { DayOfWeek } from "@/db/types/group";
@@ -52,6 +43,7 @@ import {
 import { Tournament } from "@/db/types/tournament";
 import { getFideRatingById } from "@/actions/participant";
 import { DwzPlayerSelect } from "./dwz-player-select";
+import { RoleFormActions } from "./role-form-actions";
 import { HSK_VKZ } from "@/lib/dsb/constants";
 import type { DsbPlayerCandidate } from "@/lib/dsb/types";
 import { toast } from "sonner";
@@ -85,7 +77,6 @@ export function ParticipateForm({
   profile,
 }: Props) {
   const [isPending, startTransition] = useTransition();
-  const [deleteOpen, setDeleteOpen] = useState(false);
   const form = useForm<z.infer<typeof participantFormSchema>>({
     resolver: zodResolver(participantFormSchema),
     defaultValues: {
@@ -127,25 +118,19 @@ export function ParticipateForm({
     (candidate: DsbPlayerCandidate) => {
       startTransition(async () => {
         form.setValue("dsbPersonId", candidate.nuLigaPersonId);
+        form.setValue("dwzRating", candidate.dwzRating ?? undefined);
+        form.setValue("birthYear", candidate.birthYear ?? undefined);
+        form.setValue("gender", candidate.gender ?? undefined);
+        form.setValue("fideId", candidate.fideId ?? undefined);
 
-        if (candidate.dwzRating != null) {
-          form.setValue("dwzRating", candidate.dwzRating);
-        }
-        if (candidate.birthYear != null) {
-          form.setValue("birthYear", candidate.birthYear);
-        }
-        if (candidate.gender != null) {
-          form.setValue("gender", candidate.gender);
-        }
+        let fideRating: number | undefined;
         if (candidate.fideId != null) {
-          form.setValue("fideId", candidate.fideId);
           try {
-            const fideRating = await getFideRatingById(candidate.fideId);
-            if (fideRating != null) {
-              form.setValue("fideRating", fideRating);
-            }
+            fideRating =
+              (await getFideRatingById(candidate.fideId)) ?? undefined;
           } catch {}
         }
+        form.setValue("fideRating", fideRating);
 
         toast.success("Deine Daten wurden aus der DSB-Datenbank übernommen.");
       });
@@ -373,7 +358,6 @@ export function ParticipateForm({
                 firstName={profile.firstName}
                 lastName={profile.lastName}
                 vkz={chessClubType === DEFAULT_CLUB_KEY ? HSK_VKZ : null}
-                disabled={isPending}
                 autoApply={!hasInitialRatingData}
                 onSelect={handleDsbCandidateSelect}
               />
@@ -669,57 +653,14 @@ export function ParticipateForm({
           )}
         />
 
-        <div className="flex items-center gap-2">
-          <Button
-            disabled={isPending}
-            type="submit"
-            className="w-full sm:w-auto"
-          >
-            Änderungen speichern
-          </Button>
-          {canDelete && tournament.stage === "registration" ? (
-            <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-              <DialogTrigger asChild>
-                <Button
-                  disabled={isPending}
-                  type="button"
-                  className="w-full sm:w-auto"
-                  variant={"outline"}
-                >
-                  Anmeldung löschen
-                </Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Anmeldung löschen</DialogTitle>
-                  <DialogDescription>
-                    Möchtest du deine Anmeldung zum Klubturnier wirklich
-                    löschen? Deine Angaben werden entfernt. Du kannst dich
-                    während der Anmeldephase jederzeit erneut anmelden.
-                  </DialogDescription>
-                </DialogHeader>
-                <DialogFooter>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    disabled={isPending}
-                    onClick={() => setDeleteOpen(false)}
-                  >
-                    Abbrechen
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    disabled={isPending}
-                    onClick={handleDelete}
-                  >
-                    {isPending ? "Wird gelöscht..." : "Anmeldung löschen"}
-                  </Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          ) : null}
-        </div>
+        <RoleFormActions
+          isPending={isPending}
+          onDelete={
+            canDelete && tournament.stage === "registration"
+              ? handleDelete
+              : undefined
+          }
+        />
       </form>
     </Form>
   );

--- a/src/components/klubturnier-anmeldung/forms/referee-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/referee-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useForm } from "react-hook-form";
-import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -24,6 +23,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import z from "zod";
 import { useTransition } from "react";
 import { MatchDaysCheckboxes } from "./matchday-selection";
+import { RoleFormActions } from "./role-form-actions";
 import { removePreferredFromSecondary } from "@/lib/match-days";
 import { DayOfWeek } from "@/db/types/group";
 
@@ -180,25 +180,14 @@ export function RefereeForm({
             </FormItem>
           )}
         />
-        <div className="flex items-center gap-2">
-          <Button
-            disabled={isPending}
-            type="submit"
-            className="w-full sm:w-auto"
-          >
-            Änderungen speichern
-          </Button>
-          {initialValues !== undefined && tournamentStage === "registration" ? (
-            <Button
-              disabled={isPending}
-              onClick={handleDelete}
-              className="w-full sm:w-auto "
-              variant={"outline"}
-            >
-              Änderungen verwerfen
-            </Button>
-          ) : null}
-        </div>
+        <RoleFormActions
+          isPending={isPending}
+          onDelete={
+            initialValues !== undefined && tournamentStage === "registration"
+              ? handleDelete
+              : undefined
+          }
+        />
       </form>
     </Form>
   );

--- a/src/components/klubturnier-anmeldung/forms/role-form-actions.tsx
+++ b/src/components/klubturnier-anmeldung/forms/role-form-actions.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+type Props = {
+  isPending: boolean;
+  onDelete?: () => void;
+};
+
+export function RoleFormActions({ isPending, onDelete }: Props) {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  return (
+    <div className="flex items-center justify-end gap-2">
+      {onDelete ? (
+        <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+          <DialogTrigger asChild>
+            <Button
+              disabled={isPending}
+              type="button"
+              className="w-full sm:w-auto"
+              variant={"outline"}
+            >
+              Anmeldung löschen
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Anmeldung löschen</DialogTitle>
+              <DialogDescription>
+                Möchtest du deine Anmeldung wirklich löschen? Deine Angaben
+                werden entfernt. Du kannst dich während der Anmeldephase
+                jederzeit erneut anmelden.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isPending}
+                onClick={() => setDeleteOpen(false)}
+              >
+                Abbrechen
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                disabled={isPending}
+                onClick={onDelete}
+              >
+                {isPending ? "Wird gelöscht..." : "Anmeldung löschen"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+      <Button disabled={isPending} type="submit" className="w-full sm:w-auto">
+        Änderungen speichern
+      </Button>
+    </div>
+  );
+}

--- a/src/components/klubturnier-anmeldung/forms/setup-helper-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/setup-helper-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useForm } from "react-hook-form";
-import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -22,6 +21,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import z from "zod";
 import { useTransition } from "react";
 import { MatchDaysCheckboxes } from "./matchday-selection";
+import { RoleFormActions } from "./role-form-actions";
 import { setupHelperFormSchema } from "@/schema/setupHelper";
 import { removePreferredFromSecondary } from "@/lib/match-days";
 import { DayOfWeek } from "@/db/types/group";
@@ -155,25 +155,14 @@ export function SetupHelperForm({
             </FormItem>
           )}
         />
-        <div className="flex items-center gap-2">
-          <Button
-            disabled={isPending}
-            type="submit"
-            className="w-full sm:w-auto"
-          >
-            Änderungen speichern
-          </Button>
-          {initialValues !== undefined && tournamentStage === "registration" ? (
-            <Button
-              disabled={isPending}
-              onClick={handleDelete}
-              className="w-full sm:w-auto "
-              variant={"outline"}
-            >
-              Änderungen verwerfen
-            </Button>
-          ) : null}
-        </div>
+        <RoleFormActions
+          isPending={isPending}
+          onDelete={
+            initialValues !== undefined && tournamentStage === "registration"
+              ? handleDelete
+              : undefined
+          }
+        />
       </form>
     </Form>
   );

--- a/src/components/klubturnier-anmeldung/role-card.tsx
+++ b/src/components/klubturnier-anmeldung/role-card.tsx
@@ -5,7 +5,7 @@ import {
   AccordionTrigger,
   AccordionContent,
 } from "@/components/ui/accordion";
-import { CheckCircle2, LucideIcon } from "lucide-react";
+import { LucideIcon } from "lucide-react";
 import React, { PropsWithChildren } from "react";
 
 export function RoleCard({
@@ -43,11 +43,6 @@ export function RoleCard({
             <p className="text-sm text-muted-foreground">{description}</p>
           </div>
         </div>
-        {completed && (
-          <span className="ml-4 flex-shrink-0">
-            <CheckCircle2 className="h-6 w-6 text-green-600" />
-          </span>
-        )}
       </AccordionTrigger>
       <AccordionContent className="md:p-4 md:pt-0">{children}</AccordionContent>
     </AccordionItem>

--- a/src/components/klubturnier-anmeldung/roles-manager.tsx
+++ b/src/components/klubturnier-anmeldung/roles-manager.tsx
@@ -76,7 +76,7 @@ export function RolesManager({
   const canDeleteParticipant = rolesData.participant != null;
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
-  const [accordionValue, setAccordionValue] = useState<string>();
+  const [accordionValue, setAccordionValue] = useState("");
 
   const handleParticipateFormSubmit = async (
     data: z.infer<typeof participantFormSchema>,
@@ -86,12 +86,16 @@ export function RolesManager({
       toast.error("Deine Anmeldung konnte nicht gespeichert werden.");
       return;
     }
+    toast.success("Deine Anmeldung wurde gespeichert.");
+    setAccordionValue("");
     router.refresh();
   };
 
   const handleDeleteParticipant = async () => {
     if (rolesData.participant) {
       await deleteParticipant(tournament.id, rolesData.participant.id);
+      toast.success("Deine Anmeldung wurde gelöscht.");
+      setAccordionValue("");
       router.refresh();
     }
   };


### PR DESCRIPTION
## Summary
- Auto-Apply in der DSB-Spielersuche läuft nur noch einmalig beim initialen Laden statt bei jeder debounced Eingabe, damit eine manuelle Namenskorrektur nicht mehr versehentlich einen falschen Treffer automatisch übernimmt
- DWZ/Elo/Geburtsjahr/Geschlecht/FIDE-ID werden bei fehlendem Wert im gewählten DSB-Kandidaten jetzt explizit geleert statt einen alten Wert stehen zu lassen
- Rotes Accent-Highlight/Skeleton-Puls in der DSB-Suche durch neutrale Farben ersetzt, Büroklammer-Icon signalisiert erfolgreiche Verknüpfung
- Grünen Haken-Badge bei abgeschlossenen Rollen entfernt (grün eingefärbtes Icon reicht als Signal)
- Speichern/Löschen aller fünf Rollen-Formulare (Spieler, Schiedsrichter, Aufbauhelfer, Eingabehelfer, Turniergericht) auf eine gemeinsame `RoleFormActions`-Komponente vereinheitlicht, inkl. Toast-Feedback und Zuklappen des Akkordeons nach erfolgreichem Speichern/Löschen

Closes #202

## Test plan
- [x] `bun run lint`
- [x] `bun run build`
- [x] Manuell im Browser: DSB-Suche mit abweichendem Namen manuell korrigieren, prüfen dass kein Auto-Apply mehr während der Korrektur passiert
- [x] Manuell im Browser: Speichern/Löschen für alle fünf Rollen-Formulare durchklicken (Toast + Zuklappen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)