### PR TITLE
feat(logging): Admin-Verlauf mit Aktivitäts-Zeitleiste und Feld-Diffs

### DIFF
--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: frontend-design
+description: Guidance for distinctive, intentional visual design when building new UI or reshaping an existing one. Helps with aesthetic direction, typography, and making choices that don't read as templated defaults.
+license: Complete terms in LICENSE.txt
+---
+
+# Frontend Design
+
+Approach this as the design lead at a small studio known for giving every client a visual identity that could not be mistaken for anyone else's. This client has already rejected proposals that felt templated, and is paying for a distinctive point of view: make deliberate, opinionated choices about palette, typography, and layout that are specific to this brief, and take one real aesthetic risk you can justify.
+
+## Ground it in the subject
+
+If the brief does not pin down what the product or subject is, pin it yourself before designing: name one concrete subject, its audience, and the page's single job, and state your choice. If there's any information in your memory about the human's preferences, context about what they're building, or designs you've made before – use that as a hint. The subject's own world, its materials, instruments, artifacts, and vernacular, is where distinctive choices come from. Build with the brief's real content and subject matter throughout.
+
+## Design principles
+
+For web designs, the hero is a thesis. Open with the most characteristic thing in the subject's world, in whatever form makes sense for it: a headline, an image, an animation, a live demo, an interactive moment. Be deliberate with your choice: a big number with a small label, supporting stats, and a gradient accent is the template answer, only use if that's truly the best option.
+
+Typography carries the personality of the page. Pair the display and body faces deliberately, not the same families you would reach for on any other project, and set a clear type scale with intentional weights, widths, and spacing. Make the type treatment itself a memorable part of the design, not a neutral delivery vehicle for the content.
+
+Structure is information. Structural devices, numbering, eyebrows, dividers, labels, should encode something true about the content, not decorate it. Many generic designs use numbered markers (01 / 02 / 03), but that's only appropriate if the content actually is a sequence - like a real process or a typed timeline where order carries information the reader needs. Question if choices like numbered markers actually make sense before incorporating them.
+
+Leverage motion deliberately. Think about where and if animation can serve the subject: a page-load sequence, a scroll-triggered reveal, hover micro-interactions, ambient atmosphere. An orchestrated moment usually lands harder than scattered effects; choose what the direction calls for. However, sometimes less is more, and extra animation contributes to the feeling that the design is AI-generated.
+
+Match complexity to the vision. Maximalist directions need elaborate execution; minimal directions need precision in spacing, type, and detail. Elegance is executing the chosen vision well.
+
+Consider written content carefully. Often a design brief may not contain real content, and it's up to you to come up with copy. Copy can make a design feel as templated as the design itself. See the below section on writing for more guidance.
+
+## Process: brainstorm, explore, plan, critique, build, critique again
+
+For calibration: AI-generated design right now clusters around three looks: (1) a warm cream background (near #F4F1EA) with a high-contrast serif display and a terracotta accent; (2) a near-black background with a single bright acid-green or vermilion accent; (3) a broadsheet-style layout with hairline rules, zero border-radius, and dense newspaper-like columns. All three are legitimate for some briefs, but they are defaults rather than choices, and they appear regardless of subject. Where the brief pins down a visual direction, follow it exactly — the brief's own words always win, including when it asks for one of these looks. Where it leaves an axis free, don't spend that freedom on one of these defaults. Just like a human designer who's hired, there's often a careful balance between doing what you're good at and taking each project as a chance to experiment and learn.
+
+Work in two passes. First, brainstorm a short design plan based on the human's design brief: create a compact token system with color, type, layout, and signature. Color: describe the palette as 4–6 named hex values. Type: the typefaces for 2+ roles (a characterful display face that's used with restraint, a complementary body face, and a utility face for captions or data if needed). Layout: a layout concept, using one-sentence prose descriptions and ASCII wireframes to ideate and compare. Signature: the single unique element this page will be remembered by that embodies the brief in an appropriate way.
+
+Then review that plan against the brief before building: if any part of it reads like the generic default you would produce for any similar page (work through a similar prompt to see if you arrive somewhere similar) rather than a choice made for this specific brief — revise that part, say what you changed and why. Only after you've confirmed the relative uniqueness of your design plan should you start to write the code, following the revised plan exactly and deriving every color and type decision from it.
+
+When writing the code, be careful of structuring your CSS selector specificities. It's easy to generate CSS classes that cancel each other out (especially with a type-based selector like .section and a element-based selector like .cta). This can happen often with paddings/margins between sections.
+
+Try to do a lot of this planning and iteration in your thinking, and only show ideas to the user when you have higher confidence it'll delight them.
+
+## Restraint and self-critique
+
+Spend your boldness in one place. Let the signature element be the one memorable thing, keep everything around it quiet and disciplined, and cut any decoration that does not serve the brief. Not taking a risk can be a risk itself! Build to a quality floor without announcing it: responsive down to mobile, visible keyboard focus, reduced motion respected. Critique your own work as you build, taking screenshots if your environment supports it – a picture is worth 1000 tokens. Consider Chanel's advice: before leaving the house, take a look in the mirror and remove one accessory. Human creators have memory and always try to do something new, so if you have a space to quickly jot down notes about what you've tried, it can help you in future passes.
+
+## More on writing in design
+
+Words appear in a design for one reason: to make it easier to understand, and therefore easier to use. They are design material, not decoration. Bring the same intentionality to copy that you would bring to spacing and color. Before writing anything, ask what the design needs to say, and how it can best be said to help the person navigate the experience.
+
+Write from the end user's side of the screen. Name things by what people control and recognize, never by how the system is built. A person manages notifications, not webhook config. Describe what something does in plain terms rather than selling it. Being specific is always better than being clever.
+
+Use active voice as default. A control should say exactly what happens when it's used: "Save changes," not "Submit." An action keeps the same name through the whole flow, so the button that says "Publish" produces a toast that says "Published." The vocabulary of an interface is the signposting for someone navigating the product. Cohesion and consistency are how people learn their way around.
+
+Treat failure and emptiness as moments for direction, not mood. Explain what went wrong and how to fix it, in the interface's voice rather than a person's. Errors don't apologize, and they are never vague about what happened. An empty screen is an invitation to act.
+
+Keep the register conversational and tuned: plain verbs, sentence case, no filler, with tone matched to the brand and the audience. Let each element do exactly one job. A label labels, an example demonstrates, and nothing quietly does double duty.

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-me
+description: A relentless interview to sharpen a plan or design.
+disable-model-invocation: true
+---
+
+Call the Skill tool with "grilling".

--- a/.claude/skills/grill-me/agents/openai.yaml
+++ b/.claude/skills/grill-me/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Grill Me"
+  short_description: "Sharpen a plan through interview"
+policy:
+  allow_implicit_invocation: false

--- a/.claude/skills/grilling/SKILL.md
+++ b/.claude/skills/grilling/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: grilling
+description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or uses any 'grill' trigger phrases.
+---
+
+Interview the user relentlessly until you reach a shared understanding. Map this as a **design tree**: every decision branches into the decisions that hang off it.
+
+Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled: the questions you can ask _now_ without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round.
+
+Format a round like so:
+
+```
+❓ **Q1** - **<question title>**: <question body, might be multiple paragraphs, including multiple choices>
+
+➡️ <your recommended answer>
+
+---
+
+❓ **Q2** - **<question title>**: <question body, might be multiple paragraphs, including multiple choices>
+
+➡️ <your recommended answer>
+```
+
+Each round the user answers reshapes the tree: settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier and ask the next round. A question whose answer depends on another question still open in this round belongs to a _later_ round, not this one.
+
+Finding _facts_ is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, etc.), dispatch a sub-agent to find it; don't ask the user for anything you could look up yourself. Don't block on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait for the sub-agent to report; ask the rest of the frontier now. The _decisions_ are the user's: put each to them and wait.
+
+The session is done when the frontier is empty: every branch of the design tree visited, nothing left silently assumed. Do not act on it until the user confirms you have reached a shared understanding.

--- a/.claude/skills/grilling/agents/openai.yaml
+++ b/.claude/skills/grilling/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Grilling"
+  short_description: "Stress-test thinking a round of questions at a time"

--- a/drizzle/0029_open_skrulls.sql
+++ b/drizzle/0029_open_skrulls.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "page_view" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "page_view_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"user_id" text NOT NULL,
+	"path" text NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"deleted_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "participant_change_log" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "participant_change_log_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"profile_id" integer NOT NULL,
+	"tournament_id" integer NOT NULL,
+	"changes" jsonb NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"deleted_at" timestamp
+);

--- a/drizzle/meta/0029_snapshot.json
+++ b/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,2045 @@
+{
+  "id": "55007aa5-2157-4b04-9302-37c79c53f8fd",
+  "prevId": "729b2d76-eba6-443a-8a6f-a0b34073c9f3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "white_player_id": {
+          "name": "white_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "black_player_id": {
+          "name": "black_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pgn_id": {
+          "name": "pgn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_number": {
+          "name": "board_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_postponement": {
+      "name": "game_postponement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_postponement_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponing_participant_id": {
+          "name": "postponing_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postponed_by_profile_id": {
+          "name": "postponed_by_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group": {
+      "name": "group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "group_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_tournament_id_group_number_pk": {
+          "name": "group_tournament_id_group_number_pk",
+          "columns": [
+            "tournament_id",
+            "group_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.juror": {
+      "name": "juror",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "juror_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "juror_tournament_id_profile_id_unique": {
+          "name": "juror_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday": {
+      "name": "matchday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "matchday_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_week_id": {
+          "name": "tournament_week_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_needed": {
+          "name": "referee_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_game": {
+      "name": "matchday_game",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_game_matchday_id_game_id_pk": {
+          "name": "matchday_game_matchday_id_game_id_pk",
+          "columns": [
+            "matchday_id",
+            "game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_referee": {
+      "name": "matchday_referee",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referee_id": {
+          "name": "referee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_referee_matchday_id_referee_id_pk": {
+          "name": "matchday_referee_matchday_id_referee_id_pk",
+          "columns": [
+            "matchday_id",
+            "referee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchday_setup_helper": {
+      "name": "matchday_setup_helper",
+      "schema": "",
+      "columns": {
+        "matchday_id": {
+          "name": "matchday_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_helper_id": {
+          "name": "setup_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchday_setup_helper_matchday_id_setup_helper_id_pk": {
+          "name": "matchday_setup_helper_matchday_id_setup_helper_id_pk",
+          "columns": [
+            "matchday_id",
+            "setup_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_match_entering_helper": {
+      "name": "group_match_entering_helper",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_entering_helper_id": {
+          "name": "match_entering_helper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_match_entering_helper_group_id_match_entering_helper_id_pk": {
+          "name": "group_match_entering_helper_group_id_match_entering_helper_id_pk",
+          "columns": [
+            "group_id",
+            "match_entering_helper_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_entering_helper": {
+      "name": "match_entering_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "match_entering_helper_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_groups_to_enter": {
+          "name": "number_of_groups_to_enter",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_entering_helper_tournament_id_profile_id_unique": {
+          "name": "match_entering_helper_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_view": {
+      "name": "page_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "page_view_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant": {
+      "name": "participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "participant_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chess_club": {
+          "name": "chess_club",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'m'"
+        },
+        "dwz_rating": {
+          "name": "dwz_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_rating": {
+          "name": "fide_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dsb_person_id": {
+          "name": "dsb_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_club_id": {
+          "name": "zps_club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zps_player_id": {
+          "name": "zps_player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_days": {
+          "name": "secondary_match_days",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "not_available_days": {
+          "name": "not_available_days",
+          "type": "date[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_fee_payed": {
+          "name": "entry_fee_payed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exercise_promotion_right": {
+          "name": "exercise_promotion_right",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participant_tournament_id_profile_id_unique": {
+          "name": "participant_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "participant_secondary_match_days_no_preferred": {
+          "name": "participant_secondary_match_days_no_preferred",
+          "value": "NOT (\"participant\".\"preferred_match_day\" = ANY(\"participant\".\"secondary_match_days\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.participant_group": {
+      "name": "participant_group",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_position": {
+          "name": "group_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "participant_group_group_id_participant_id_group_position_pk": {
+          "name": "participant_group_group_id_participant_id_group_position_pk",
+          "columns": [
+            "group_id",
+            "participant_id",
+            "group_position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_change_log": {
+      "name": "participant_change_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "participant_change_log_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pgn": {
+      "name": "pgn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pgn_game_id_unique": {
+          "name": "pgn_game_id_unique",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pgn_game_id_game_id_fk": {
+          "name": "pgn_game_id_game_id_fk",
+          "tableFrom": "pgn",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "profile_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_title": {
+          "name": "academic_title",
+          "type": "academic_title",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_email_unique": {
+          "name": "profile_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referee": {
+      "name": "referee",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "referee_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "referee_tournament_id_profile_id_unique": {
+          "name": "referee_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "referee_secondary_match_days_no_preferred": {
+          "name": "referee_secondary_match_days_no_preferred",
+          "value": "NOT (\"referee\".\"preferred_match_day\" = ANY(\"referee\".\"secondary_match_day\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.setup_helper": {
+      "name": "setup_helper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "setup_helper_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_match_day": {
+          "name": "preferred_match_day",
+          "type": "match_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_match_day": {
+          "name": "secondary_match_day",
+          "type": "match_day[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "setup_helper_tournament_id_profile_id_unique": {
+          "name": "setup_helper_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "setup_helper_secondary_match_days_no_preferred": {
+          "name": "setup_helper_secondary_match_days_no_preferred",
+          "value": "NOT (\"setup_helper\".\"preferred_match_day\" = ANY(\"setup_helper\".\"secondary_match_day\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tournament": {
+      "name": "tournament",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_rounds": {
+          "name": "number_of_rounds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_registration_date": {
+          "name": "end_registration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_announcement_offset_days": {
+          "name": "group_announcement_offset_days",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_limit": {
+          "name": "time_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_clocks_digital": {
+          "name": "all_clocks_digital",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tie_break_method": {
+          "name": "tie_break_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "software": {
+          "name": "software",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "tournament_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registration'"
+        },
+        "game_start_time": {
+          "name": "game_start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'19:00:00'"
+        },
+        "organizer_profile_id": {
+          "name": "organizer_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "one_tournament_in_registration": {
+          "name": "one_tournament_in_registration",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tournament\".\"stage\" = 'registration'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_slug_unique": {
+          "name": "tournament_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_week": {
+      "name": "tournament_week",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_week_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_week_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "week_number": {
+          "name": "week_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainer": {
+      "name": "trainer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "trainer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trainer_tournament_id_profile_id_unique": {
+          "name": "trainer_tournament_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.academic_title": {
+      "name": "academic_title",
+      "schema": "public",
+      "values": [
+        "Dr."
+      ]
+    },
+    "public.result": {
+      "name": "result",
+      "schema": "public",
+      "values": [
+        "1:0",
+        "0:1",
+        "½-½",
+        "+:-",
+        "-:+",
+        "-:-",
+        "0-½",
+        "½-0"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "m",
+        "f"
+      ]
+    },
+    "public.match_day": {
+      "name": "match_day",
+      "schema": "public",
+      "values": [
+        "tuesday",
+        "thursday",
+        "friday"
+      ]
+    },
+    "public.tournament_stage": {
+      "name": "tournament_stage",
+      "schema": "public",
+      "values": [
+        "registration",
+        "running",
+        "done"
+      ]
+    },
+    "public.tournament_week_status": {
+      "name": "tournament_week_status",
+      "schema": "public",
+      "values": [
+        "regular",
+        "catch-up"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1785427059296,
       "tag": "0028_backfill_dsb_person_id",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1787240016841,
+      "tag": "0029_open_skrulls",
+      "breakpoints": true
     }
   ]
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "skills": {
+    "frontend-design": {
+      "source": "anthropics/claude-code",
+      "sourceType": "github",
+      "skillPath": "plugins/frontend-design/skills/frontend-design/SKILL.md",
+      "computedHash": "3e0be122a3db8206b6d0d6b07cca898b5c75fb9b7b2101abe143fb2851734d2e"
+    },
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grill-me/SKILL.md",
+      "computedHash": "5e0c683385eafd83f106ac6c9d67dfbbfe5aa4b3fe65aad114eb1055a99c818f"
+    },
+    "grilling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grilling/SKILL.md",
+      "computedHash": "4fa026e5979770347b3357ff5139e1e41d21c3a9f7335e9cd2811cb5b8d32f2f"
+    }
+  }
+}

--- a/src/actions/page-view.ts
+++ b/src/actions/page-view.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { db } from "@/db/client";
+import { pageView } from "@/db/schema/pageView";
+import { auth } from "@/auth/utils";
+
+export async function logPageView(path: string) {
+  const session = await auth();
+  if (!session) {
+    return;
+  }
+  if (typeof path !== "string" || !path.startsWith("/") || path.length > 512) {
+    return;
+  }
+
+  try {
+    await db.insert(pageView).values({ userId: session.user.id, path });
+  } catch (error) {
+    console.error("Failed to log page view:", error);
+  }
+}

--- a/src/actions/participant.ts
+++ b/src/actions/participant.ts
@@ -35,7 +35,7 @@ export const createParticipant = action(async (
       data.preferredMatchDay,
       data.secondaryMatchDays,
     ),
-    "Preferred match day cannot also be a secondary match day",
+    `Preferred match day cannot also be a secondary match day (tournament ${tournamentId})`,
   );
 
   const session = await authWithRedirect();
@@ -60,11 +60,11 @@ export const createParticipant = action(async (
   const tournament = await getTournamentById(tournamentId);
   invariant(
     tournament != null && tournament.stage === "registration",
-    "Tournament not found or not in registration stage",
+    `Tournament ${tournamentId} not found or not in registration stage`,
   );
 
   const currentProfile = await getProfileByUserId(session.user.id);
-  invariant(currentProfile, "Profile not found");
+  invariant(currentProfile, `Profile not found for user ${session.user.id}`);
 
   const promotionEligibility = await getPromotionEligibility(currentProfile.id);
   const exercisePromotionRight = promotionEligibility
@@ -97,6 +97,7 @@ export const createParticipant = action(async (
     .onConflictDoUpdate({
       target: [participant.tournamentId, participant.profileId],
       set: {
+        updatedAt: new Date(),
         chessClub,
         gender: data.gender,
         dwzRating: data.dwzRating,
@@ -118,21 +119,21 @@ export const createParticipant = action(async (
     });
 });
 
-export async function deleteParticipant(
+export const deleteParticipant = action(async (
   tournamentId: number,
   participantId: number,
-) {
+) => {
   const session = await authWithRedirect();
 
   const tournament = await getTournamentById(tournamentId);
-  invariant(tournament != null, "Tournament not found");
+  invariant(tournament != null, `Tournament ${tournamentId} not found`);
   invariant(
     tournament.stage === "registration",
-    "Cannot delete participant in this stage",
+    `Cannot delete participant ${participantId} in tournament ${tournamentId} (stage ${tournament.stage})`,
   );
 
   const currentProfile = await getProfileByUserId(session.user.id);
-  invariant(currentProfile, "Profile not found");
+  invariant(currentProfile, `Profile not found for user ${session.user.id}`);
 
   await db
     .delete(participant)
@@ -143,7 +144,7 @@ export async function deleteParticipant(
         eq(participant.tournamentId, tournament.id),
       ),
     );
-}
+});
 
 export async function searchDsbPlayers(
   firstName: string,

--- a/src/actions/participant.ts
+++ b/src/actions/participant.ts
@@ -8,7 +8,12 @@ import { participantFormSchema } from "@/schema/participant";
 import { authWithRedirect } from "@/auth/utils";
 import { getTournamentById } from "@/db/repositories/tournament";
 import { getProfileByUserId } from "@/db/repositories/profile";
-import { getParticipantsWithDsbPersonIdByTournamentId } from "@/db/repositories/participant";
+import {
+  getParticipantByProfileIdAndTournamentId,
+  getParticipantsWithDsbPersonIdByTournamentId,
+} from "@/db/repositories/participant";
+import { participantChangeLog } from "@/db/schema/participantChangeLog";
+import { computeParticipantChanges } from "@/lib/activity";
 import { getPromotionEligibility } from "@/services/promotion";
 import { and, eq } from "drizzle-orm";
 import {
@@ -71,51 +76,65 @@ export const createParticipant = action(async (
     ? (data.exercisePromotionRight ?? false)
     : null;
 
+  const values = {
+    chessClub,
+    title: data.title === "noTitle" ? null : data.title,
+    gender: data.gender,
+    dwzRating: data.dwzRating,
+    fideRating: data.fideRating,
+    fideId: data.fideId,
+    nationality: data.nationality,
+    birthYear,
+    birthDate: data.birthDate,
+    preferredMatchDay: data.preferredMatchDay,
+    secondaryMatchDays: data.secondaryMatchDays,
+    notAvailableDays: data.notAvailableDays,
+    dsbPersonId: data.dsbPersonId,
+    zpsClubId: data.zpsClub,
+    zpsPlayerId: data.zpsPlayer,
+    entryFeePayed,
+    exercisePromotionRight,
+  };
+
+  const existing = await getParticipantByProfileIdAndTournamentId(
+    currentProfile.id,
+    tournament.id,
+  );
+
+  if (existing) {
+    const changes = computeParticipantChanges(
+      existing,
+      values,
+      Object.keys(values) as (keyof typeof values)[],
+    );
+    if (Object.keys(changes).length === 0) {
+      return;
+    }
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(participant)
+        .set({ ...values, updatedAt: new Date() })
+        .where(eq(participant.id, existing.id));
+      await tx.insert(participantChangeLog).values({
+        profileId: currentProfile.id,
+        tournamentId: tournament.id,
+        changes,
+      });
+    });
+    return;
+  }
+
   await db
     .insert(participant)
     .values({
       profileId: currentProfile.id,
       tournamentId: tournament.id,
-      chessClub,
-      title: data.title === "noTitle" ? null : data.title,
-      gender: data.gender,
-      dwzRating: data.dwzRating,
-      fideRating: data.fideRating,
-      fideId: data.fideId,
-      nationality: data.nationality,
-      birthYear,
-      birthDate: data.birthDate,
-      preferredMatchDay: data.preferredMatchDay,
-      secondaryMatchDays: data.secondaryMatchDays,
-      notAvailableDays: data.notAvailableDays,
-      dsbPersonId: data.dsbPersonId,
-      zpsClubId: data.zpsClub,
-      zpsPlayerId: data.zpsPlayer,
-      entryFeePayed,
-      exercisePromotionRight,
+      ...values,
     })
     .onConflictDoUpdate({
       target: [participant.tournamentId, participant.profileId],
-      set: {
-        updatedAt: new Date(),
-        chessClub,
-        gender: data.gender,
-        dwzRating: data.dwzRating,
-        fideRating: data.fideRating,
-        fideId: data.fideId,
-        nationality: data.nationality,
-        title: data.title === "noTitle" ? null : data.title,
-        birthYear,
-        birthDate: data.birthDate,
-        preferredMatchDay: data.preferredMatchDay,
-        secondaryMatchDays: data.secondaryMatchDays,
-        notAvailableDays: data.notAvailableDays,
-        dsbPersonId: data.dsbPersonId,
-        zpsClubId: data.zpsClub,
-        zpsPlayerId: data.zpsPlayer,
-        entryFeePayed,
-        exercisePromotionRight,
-      },
+      set: { ...values, updatedAt: new Date() },
     });
 });
 

--- a/src/actions/participant.ts
+++ b/src/actions/participant.ts
@@ -102,11 +102,7 @@ export const createParticipant = action(async (
   );
 
   if (existing) {
-    const changes = computeParticipantChanges(
-      existing,
-      values,
-      Object.keys(values) as (keyof typeof values)[],
-    );
+    const changes = computeParticipantChanges(existing, values);
     if (Object.keys(changes).length === 0) {
       return;
     }

--- a/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
+++ b/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
@@ -2,7 +2,6 @@ import { authWithRedirect } from "@/auth/utils";
 import { redirect } from "next/navigation";
 import { tournamentPath } from "@/lib/navigation";
 import { getAllProfiles } from "@/db/repositories/admin";
-import { getTournamentBySlug } from "@/db/repositories/tournament";
 import { getActivityTimelineForProfile } from "@/db/repositories/activity";
 import {
   ACTIVITY_EVENT_TYPES,
@@ -36,10 +35,7 @@ export default async function Page({
   const query = await searchParams;
   const profileId = query.profileId ? Number(query.profileId) : undefined;
 
-  const [profiles, tournament] = await Promise.all([
-    getAllProfiles(),
-    getTournamentBySlug(slug),
-  ]);
+  const profiles = await getAllProfiles();
 
   const availableTypes: ActivityEventType[] = [...ACTIVITY_EVENT_TYPES];
   const types = parseTypes(query.types, availableTypes);
@@ -52,7 +48,6 @@ export default async function Page({
           from: from ? startOfDay(from) : undefined,
           to: to ? endOfDay(to) : undefined,
           types,
-          tournamentId: tournament?.id,
         })
       : null;
 
@@ -63,12 +58,8 @@ export default async function Page({
           Anmeldungsverlauf
         </h1>
         <p className="text-gray-600">
-          Konto-, Login- und Anmeldungsaktivität einzelner Nutzer einsehen
-          {tournament ? (
-            <>
-              : <strong>{tournament.name}</strong>
-            </>
-          ) : null}
+          Konto-, Login- und Anmeldungsaktivität einzelner Nutzer über alle
+          Turniere einsehen.
         </p>
       </div>
 

--- a/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
+++ b/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
@@ -7,7 +7,7 @@ import {
   ACTIVITY_EVENT_TYPES,
   type ActivityEventType,
 } from "@/lib/activity";
-import { parseDateOnly } from "@/lib/date";
+import { dateOnlyRange } from "@/lib/date";
 import { ActivityFilters } from "@/components/admin/activity-filters";
 import { ActivityTable } from "@/components/admin/activity-table";
 
@@ -45,8 +45,7 @@ export default async function Page({
   const result =
     profileId != null
       ? await getActivityTimelineForProfile(profileId, {
-          from: from ? startOfDay(from) : undefined,
-          to: to ? endOfDay(to) : undefined,
+          ...dateOnlyRange(from, to),
           types,
         })
       : null;
@@ -106,12 +105,4 @@ function parseTypes(
   const requested = raw.split(",");
   const valid = available.filter((type) => requested.includes(type));
   return valid.length > 0 ? valid : available;
-}
-
-function startOfDay(dateOnly: string): Date {
-  return parseDateOnly(dateOnly).startOf("day").toJSDate();
-}
-
-function endOfDay(dateOnly: string): Date {
-  return parseDateOnly(dateOnly).endOf("day").toJSDate();
 }

--- a/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
+++ b/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
@@ -16,8 +16,6 @@ import {
 import {
   formatEventDateTime,
   parseDateOnly,
-  toDateOnly,
-  todayDateOnly,
   toLocalDateTime,
 } from "@/lib/date";
 import {
@@ -32,7 +30,6 @@ import { Badge } from "@/components/ui/badge";
 import { ActivityFilters } from "@/components/admin/activity-filters";
 
 const OVERVIEW_DEFAULT_TYPES: ActivityEventType[] = ["registered", "updated"];
-const OVERVIEW_DEFAULT_WINDOW_DAYS = 30;
 
 type SearchParams = {
   profileId?: string;
@@ -68,10 +65,7 @@ export default async function Page({
     profileId != null ? availableTypes : OVERVIEW_DEFAULT_TYPES;
   const types = parseTypes(query.types, availableTypes, defaultTypes);
 
-  const fromIsDefault = profileId == null && !query.from;
-  const from = fromIsDefault
-    ? toDateOnlyMinusDays(OVERVIEW_DEFAULT_WINDOW_DAYS)
-    : query.from;
+  const from = query.from;
   const to = query.to;
 
   const filter = {
@@ -118,16 +112,9 @@ export default async function Page({
         availableTypes={availableTypes}
         defaultTypes={defaultTypes}
         from={from}
-        fromIsDefault={fromIsDefault}
         to={to}
       />
 
-      {fromIsDefault ? (
-        <p className="text-sm text-muted-foreground">
-          Zeigt die letzten {OVERVIEW_DEFAULT_WINDOW_DAYS} Tage. Über
-          &quot;Von&quot; lässt sich weiter in die Vergangenheit blicken.
-        </p>
-      ) : null}
       {truncated ? (
         <p className="text-sm text-muted-foreground">
           Es werden nur die neuesten Einträge angezeigt — bitte den Zeitraum
@@ -198,10 +185,6 @@ function parseTypes(
   const requested = raw.split(",");
   const valid = available.filter((type) => requested.includes(type));
   return valid.length > 0 ? valid : defaults;
-}
-
-function toDateOnlyMinusDays(days: number): string {
-  return toDateOnly(parseDateOnly(todayDateOnly()).minus({ days }));
 }
 
 function startOfDay(dateOnly: string): Date {

--- a/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
+++ b/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
@@ -2,13 +2,10 @@ import { authWithRedirect } from "@/auth/utils";
 import { redirect } from "next/navigation";
 import { tournamentPath } from "@/lib/navigation";
 import { getAllProfiles } from "@/db/repositories/admin";
-import {
-  getAllTournaments,
-  getTournamentBySlug,
-} from "@/db/repositories/tournament";
+import { getTournamentBySlug } from "@/db/repositories/tournament";
 import {
   getActivityTimelineForProfile,
-  getRecentParticipantActivity,
+  getRecentActivity,
 } from "@/db/repositories/activity";
 import {
   ACTIVITY_EVENT_LABELS,
@@ -34,12 +31,11 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { ActivityFilters } from "@/components/admin/activity-filters";
 
-const OVERVIEW_TYPES: ActivityEventType[] = ["registered", "updated"];
+const OVERVIEW_DEFAULT_TYPES: ActivityEventType[] = ["registered", "updated"];
 const OVERVIEW_DEFAULT_WINDOW_DAYS = 30;
 
 type SearchParams = {
   profileId?: string;
-  tournamentId?: string;
   types?: string;
   from?: string;
   to?: string;
@@ -62,22 +58,15 @@ export default async function Page({
   const query = await searchParams;
   const profileId = query.profileId ? Number(query.profileId) : undefined;
 
-  const [profiles, tournaments, slugTournament] = await Promise.all([
+  const [profiles, tournament] = await Promise.all([
     getAllProfiles(),
-    getAllTournaments(),
     getTournamentBySlug(slug),
   ]);
 
-  const tournamentId =
-    query.tournamentId === "all"
-      ? undefined
-      : query.tournamentId
-        ? Number(query.tournamentId)
-        : slugTournament?.id;
-
-  const availableTypes: ActivityEventType[] =
-    profileId != null ? [...ACTIVITY_EVENT_TYPES] : OVERVIEW_TYPES;
-  const types = parseTypes(query.types, availableTypes);
+  const availableTypes: ActivityEventType[] = [...ACTIVITY_EVENT_TYPES];
+  const defaultTypes =
+    profileId != null ? availableTypes : OVERVIEW_DEFAULT_TYPES;
+  const types = parseTypes(query.types, availableTypes, defaultTypes);
 
   const fromIsDefault = profileId == null && !query.from;
   const from = fromIsDefault
@@ -85,21 +74,19 @@ export default async function Page({
     : query.from;
   const to = query.to;
 
-  const dateFilter = {
+  const filter = {
     from: from ? startOfDay(from) : undefined,
     to: to ? endOfDay(to) : undefined,
     types,
+    tournamentId: tournament?.id,
   };
 
   let events: ActivityEvent[];
   let truncated = false;
   if (profileId != null) {
-    events = await getActivityTimelineForProfile(profileId, dateFilter);
+    events = await getActivityTimelineForProfile(profileId, filter);
   } else {
-    const result = await getRecentParticipantActivity({
-      ...dateFilter,
-      tournamentId,
-    });
+    const result = await getRecentActivity(filter);
     events = result.events;
     truncated = result.truncated;
   }
@@ -111,7 +98,12 @@ export default async function Page({
           Anmeldungsverlauf
         </h1>
         <p className="text-gray-600">
-          Konto-, Login- und Klubturnier-Anmeldungsaktivität einsehen.
+          Konto-, Login- und Anmeldungsaktivität für das aktuelle Turnier
+          einsehen{tournament ? (
+            <>
+              : <strong>{tournament.name}</strong>
+            </>
+          ) : null}
         </p>
       </div>
 
@@ -121,11 +113,10 @@ export default async function Page({
           firstName: p.firstName,
           lastName: p.lastName,
         }))}
-        tournaments={tournaments.map((t) => ({ id: t.id, name: t.name }))}
         profileId={profileId}
-        tournamentId={tournamentId}
         types={types}
         availableTypes={availableTypes}
+        defaultTypes={defaultTypes}
         from={from}
         fromIsDefault={fromIsDefault}
         to={to}
@@ -139,8 +130,8 @@ export default async function Page({
       ) : null}
       {truncated ? (
         <p className="text-sm text-muted-foreground">
-          Es werden nur die zuletzt geänderten Anmeldungen angezeigt — bitte
-          den Zeitraum oder das Turnier weiter eingrenzen.
+          Es werden nur die neuesten Einträge angezeigt — bitte den Zeitraum
+          weiter eingrenzen.
         </p>
       ) : null}
 
@@ -172,7 +163,6 @@ function ActivityTable({
             <TableHead className="whitespace-nowrap">Zeitstempel</TableHead>
             <TableHead>Aktion</TableHead>
             {showProfileColumn ? <TableHead>Nutzer</TableHead> : null}
-            <TableHead>Turnier</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -189,7 +179,6 @@ function ActivityTable({
               {showProfileColumn ? (
                 <TableCell>{event.profileName ?? "–"}</TableCell>
               ) : null}
-              <TableCell>{event.tournamentName ?? "–"}</TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -200,14 +189,15 @@ function ActivityTable({
 
 function parseTypes(
   raw: string | undefined,
-  fallback: ActivityEventType[],
+  available: ActivityEventType[],
+  defaults: ActivityEventType[],
 ): ActivityEventType[] {
   if (!raw) {
-    return fallback;
+    return defaults;
   }
   const requested = raw.split(",");
-  const valid = fallback.filter((type) => requested.includes(type));
-  return valid.length > 0 ? valid : fallback;
+  const valid = available.filter((type) => requested.includes(type));
+  return valid.length > 0 ? valid : defaults;
 }
 
 function toDateOnlyMinusDays(days: number): string {

--- a/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
+++ b/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
@@ -3,33 +3,14 @@ import { redirect } from "next/navigation";
 import { tournamentPath } from "@/lib/navigation";
 import { getAllProfiles } from "@/db/repositories/admin";
 import { getTournamentBySlug } from "@/db/repositories/tournament";
+import { getActivityTimelineForProfile } from "@/db/repositories/activity";
 import {
-  getActivityTimelineForProfile,
-  getRecentActivity,
-} from "@/db/repositories/activity";
-import {
-  ACTIVITY_EVENT_LABELS,
   ACTIVITY_EVENT_TYPES,
-  type ActivityEvent,
   type ActivityEventType,
 } from "@/lib/activity";
-import {
-  formatEventDateTime,
-  parseDateOnly,
-  toLocalDateTime,
-} from "@/lib/date";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
+import { parseDateOnly } from "@/lib/date";
 import { ActivityFilters } from "@/components/admin/activity-filters";
-
-const OVERVIEW_DEFAULT_TYPES: ActivityEventType[] = ["registered", "updated"];
+import { ActivityTable } from "@/components/admin/activity-table";
 
 type SearchParams = {
   profileId?: string;
@@ -61,29 +42,19 @@ export default async function Page({
   ]);
 
   const availableTypes: ActivityEventType[] = [...ACTIVITY_EVENT_TYPES];
-  const defaultTypes =
-    profileId != null ? availableTypes : OVERVIEW_DEFAULT_TYPES;
-  const types = parseTypes(query.types, availableTypes, defaultTypes);
-
+  const types = parseTypes(query.types, availableTypes);
   const from = query.from;
   const to = query.to;
 
-  const filter = {
-    from: from ? startOfDay(from) : undefined,
-    to: to ? endOfDay(to) : undefined,
-    types,
-    tournamentId: tournament?.id,
-  };
-
-  let events: ActivityEvent[];
-  let truncated = false;
-  if (profileId != null) {
-    events = await getActivityTimelineForProfile(profileId, filter);
-  } else {
-    const result = await getRecentActivity(filter);
-    events = result.events;
-    truncated = result.truncated;
-  }
+  const result =
+    profileId != null
+      ? await getActivityTimelineForProfile(profileId, {
+          from: from ? startOfDay(from) : undefined,
+          to: to ? endOfDay(to) : undefined,
+          types,
+          tournamentId: tournament?.id,
+        })
+      : null;
 
   return (
     <div className="space-y-6">
@@ -92,8 +63,8 @@ export default async function Page({
           Anmeldungsverlauf
         </h1>
         <p className="text-gray-600">
-          Konto-, Login- und Anmeldungsaktivität für das aktuelle Turnier
-          einsehen{tournament ? (
+          Konto-, Login- und Anmeldungsaktivität einzelner Nutzer einsehen
+          {tournament ? (
             <>
               : <strong>{tournament.name}</strong>
             </>
@@ -110,66 +81,26 @@ export default async function Page({
         profileId={profileId}
         types={types}
         availableTypes={availableTypes}
-        defaultTypes={defaultTypes}
+        defaultTypes={availableTypes}
         from={from}
         to={to}
       />
 
-      {truncated ? (
+      {result == null ? (
         <p className="text-sm text-muted-foreground">
-          Es werden nur die neuesten Einträge angezeigt — bitte den Zeitraum
-          weiter eingrenzen.
+          Bitte einen Nutzer auswählen, um dessen Aktivität zu sehen.
         </p>
-      ) : null}
-
-      <ActivityTable events={events} showProfileColumn={profileId == null} />
-    </div>
-  );
-}
-
-function ActivityTable({
-  events,
-  showProfileColumn,
-}: {
-  events: ActivityEvent[];
-  showProfileColumn: boolean;
-}) {
-  if (events.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        Keine Aktivität im gewählten Zeitraum.
-      </p>
-    );
-  }
-
-  return (
-    <div className="border rounded-lg overflow-x-auto">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="whitespace-nowrap">Zeitstempel</TableHead>
-            <TableHead>Aktion</TableHead>
-            {showProfileColumn ? <TableHead>Nutzer</TableHead> : null}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {events.map((event, index) => (
-            <TableRow key={`${event.type}-${event.timestamp.getTime()}-${index}`}>
-              <TableCell className="whitespace-nowrap">
-                {formatEventDateTime(toLocalDateTime(event.timestamp))}
-              </TableCell>
-              <TableCell>
-                <Badge variant="secondary">
-                  {ACTIVITY_EVENT_LABELS[event.type]}
-                </Badge>
-              </TableCell>
-              {showProfileColumn ? (
-                <TableCell>{event.profileName ?? "–"}</TableCell>
-              ) : null}
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      ) : (
+        <>
+          {result.truncated ? (
+            <p className="text-sm text-muted-foreground">
+              Es werden nur die neuesten Einträge angezeigt — bitte den
+              Zeitraum weiter eingrenzen.
+            </p>
+          ) : null}
+          <ActivityTable events={result.events} />
+        </>
+      )}
     </div>
   );
 }
@@ -177,14 +108,13 @@ function ActivityTable({
 function parseTypes(
   raw: string | undefined,
   available: ActivityEventType[],
-  defaults: ActivityEventType[],
 ): ActivityEventType[] {
   if (!raw) {
-    return defaults;
+    return available;
   }
   const requested = raw.split(",");
   const valid = available.filter((type) => requested.includes(type));
-  return valid.length > 0 ? valid : defaults;
+  return valid.length > 0 ? valid : available;
 }
 
 function startOfDay(dateOnly: string): Date {

--- a/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
+++ b/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
@@ -2,7 +2,10 @@ import { authWithRedirect } from "@/auth/utils";
 import { redirect } from "next/navigation";
 import { tournamentPath } from "@/lib/navigation";
 import { getAllProfiles } from "@/db/repositories/admin";
-import { getAllTournaments } from "@/db/repositories/tournament";
+import {
+  getAllTournaments,
+  getTournamentBySlug,
+} from "@/db/repositories/tournament";
 import {
   getActivityTimelineForProfile,
   getRecentParticipantActivity,
@@ -13,7 +16,13 @@ import {
   type ActivityEvent,
   type ActivityEventType,
 } from "@/lib/activity";
-import { parseDateOnly, todayDateOnly, toLocalDateTime, formatEventDateTime } from "@/lib/date";
+import {
+  formatEventDateTime,
+  parseDateOnly,
+  toDateOnly,
+  todayDateOnly,
+  toLocalDateTime,
+} from "@/lib/date";
 import {
   Table,
   TableBody,
@@ -52,36 +61,48 @@ export default async function Page({
 
   const query = await searchParams;
   const profileId = query.profileId ? Number(query.profileId) : undefined;
-  const tournamentId = query.tournamentId
-    ? Number(query.tournamentId)
-    : undefined;
+
+  const [profiles, tournaments, slugTournament] = await Promise.all([
+    getAllProfiles(),
+    getAllTournaments(),
+    getTournamentBySlug(slug),
+  ]);
+
+  const tournamentId =
+    query.tournamentId === "all"
+      ? undefined
+      : query.tournamentId
+        ? Number(query.tournamentId)
+        : slugTournament?.id;
 
   const availableTypes: ActivityEventType[] =
     profileId != null ? [...ACTIVITY_EVENT_TYPES] : OVERVIEW_TYPES;
   const types = parseTypes(query.types, availableTypes);
 
-  const [profiles, tournaments] = await Promise.all([
-    getAllProfiles(),
-    getAllTournaments(),
-  ]);
-
-  const defaultFrom = toDateOnlyMinusDays(OVERVIEW_DEFAULT_WINDOW_DAYS);
-  const from = query.from ?? (profileId == null ? defaultFrom : undefined);
+  const fromIsDefault = profileId == null && !query.from;
+  const from = fromIsDefault
+    ? toDateOnlyMinusDays(OVERVIEW_DEFAULT_WINDOW_DAYS)
+    : query.from;
   const to = query.to;
 
-  const events =
-    profileId != null
-      ? await getActivityTimelineForProfile(profileId, {
-          from: from ? startOfDay(from) : undefined,
-          to: to ? endOfDay(to) : undefined,
-          types,
-        })
-      : await getRecentParticipantActivity({
-          from: from ? startOfDay(from) : undefined,
-          to: to ? endOfDay(to) : undefined,
-          types,
-          tournamentId,
-        });
+  const dateFilter = {
+    from: from ? startOfDay(from) : undefined,
+    to: to ? endOfDay(to) : undefined,
+    types,
+  };
+
+  let events: ActivityEvent[];
+  let truncated = false;
+  if (profileId != null) {
+    events = await getActivityTimelineForProfile(profileId, dateFilter);
+  } else {
+    const result = await getRecentParticipantActivity({
+      ...dateFilter,
+      tournamentId,
+    });
+    events = result.events;
+    truncated = result.truncated;
+  }
 
   return (
     <div className="space-y-6">
@@ -106,13 +127,20 @@ export default async function Page({
         types={types}
         availableTypes={availableTypes}
         from={from}
+        fromIsDefault={fromIsDefault}
         to={to}
       />
 
-      {profileId == null && !query.from ? (
+      {fromIsDefault ? (
         <p className="text-sm text-muted-foreground">
           Zeigt die letzten {OVERVIEW_DEFAULT_WINDOW_DAYS} Tage. Über
           &quot;Von&quot; lässt sich weiter in die Vergangenheit blicken.
+        </p>
+      ) : null}
+      {truncated ? (
+        <p className="text-sm text-muted-foreground">
+          Es werden nur die zuletzt geänderten Anmeldungen angezeigt — bitte
+          den Zeitraum oder das Turnier weiter eingrenzen.
         </p>
       ) : null}
 
@@ -137,7 +165,7 @@ function ActivityTable({
   }
 
   return (
-    <div className="border rounded-lg overflow-hidden overflow-x-auto">
+    <div className="border rounded-lg overflow-x-auto">
       <Table>
         <TableHeader>
           <TableRow>
@@ -145,7 +173,6 @@ function ActivityTable({
             <TableHead>Aktion</TableHead>
             {showProfileColumn ? <TableHead>Nutzer</TableHead> : null}
             <TableHead>Turnier</TableHead>
-            <TableHead>Details</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -163,9 +190,6 @@ function ActivityTable({
                 <TableCell>{event.profileName ?? "–"}</TableCell>
               ) : null}
               <TableCell>{event.tournamentName ?? "–"}</TableCell>
-              <TableCell className="text-muted-foreground text-sm">
-                {event.detail ?? "–"}
-              </TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -187,7 +211,7 @@ function parseTypes(
 }
 
 function toDateOnlyMinusDays(days: number): string {
-  return parseDateOnly(todayDateOnly()).minus({ days }).toISODate()!;
+  return toDateOnly(parseDateOnly(todayDateOnly()).minus({ days }));
 }
 
 function startOfDay(dateOnly: string): Date {

--- a/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
+++ b/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
@@ -1,0 +1,199 @@
+import { authWithRedirect } from "@/auth/utils";
+import { redirect } from "next/navigation";
+import { tournamentPath } from "@/lib/navigation";
+import { getAllProfiles } from "@/db/repositories/admin";
+import { getAllTournaments } from "@/db/repositories/tournament";
+import {
+  getActivityTimelineForProfile,
+  getRecentParticipantActivity,
+} from "@/db/repositories/activity";
+import {
+  ACTIVITY_EVENT_LABELS,
+  ACTIVITY_EVENT_TYPES,
+  type ActivityEvent,
+  type ActivityEventType,
+} from "@/lib/activity";
+import { parseDateOnly, todayDateOnly, toLocalDateTime, formatEventDateTime } from "@/lib/date";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { ActivityFilters } from "@/components/admin/activity-filters";
+
+const OVERVIEW_TYPES: ActivityEventType[] = ["registered", "updated"];
+const OVERVIEW_DEFAULT_WINDOW_DAYS = 30;
+
+type SearchParams = {
+  profileId?: string;
+  tournamentId?: string;
+  types?: string;
+  from?: string;
+  to?: string;
+};
+
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<SearchParams>;
+}) {
+  const session = await authWithRedirect();
+  const { slug } = await params;
+
+  if (session.user.role !== "admin") {
+    redirect(tournamentPath(slug, "/uebersicht"));
+  }
+
+  const query = await searchParams;
+  const profileId = query.profileId ? Number(query.profileId) : undefined;
+  const tournamentId = query.tournamentId
+    ? Number(query.tournamentId)
+    : undefined;
+
+  const availableTypes: ActivityEventType[] =
+    profileId != null ? [...ACTIVITY_EVENT_TYPES] : OVERVIEW_TYPES;
+  const types = parseTypes(query.types, availableTypes);
+
+  const [profiles, tournaments] = await Promise.all([
+    getAllProfiles(),
+    getAllTournaments(),
+  ]);
+
+  const defaultFrom = toDateOnlyMinusDays(OVERVIEW_DEFAULT_WINDOW_DAYS);
+  const from = query.from ?? (profileId == null ? defaultFrom : undefined);
+  const to = query.to;
+
+  const events =
+    profileId != null
+      ? await getActivityTimelineForProfile(profileId, {
+          from: from ? startOfDay(from) : undefined,
+          to: to ? endOfDay(to) : undefined,
+          types,
+        })
+      : await getRecentParticipantActivity({
+          from: from ? startOfDay(from) : undefined,
+          to: to ? endOfDay(to) : undefined,
+          types,
+          tournamentId,
+        });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">
+          Anmeldungsverlauf
+        </h1>
+        <p className="text-gray-600">
+          Konto-, Login- und Klubturnier-Anmeldungsaktivität einsehen.
+        </p>
+      </div>
+
+      <ActivityFilters
+        profiles={profiles.map((p) => ({
+          id: p.id,
+          firstName: p.firstName,
+          lastName: p.lastName,
+        }))}
+        tournaments={tournaments.map((t) => ({ id: t.id, name: t.name }))}
+        profileId={profileId}
+        tournamentId={tournamentId}
+        types={types}
+        availableTypes={availableTypes}
+        from={from}
+        to={to}
+      />
+
+      {profileId == null && !query.from ? (
+        <p className="text-sm text-muted-foreground">
+          Zeigt die letzten {OVERVIEW_DEFAULT_WINDOW_DAYS} Tage. Über
+          &quot;Von&quot; lässt sich weiter in die Vergangenheit blicken.
+        </p>
+      ) : null}
+
+      <ActivityTable events={events} showProfileColumn={profileId == null} />
+    </div>
+  );
+}
+
+function ActivityTable({
+  events,
+  showProfileColumn,
+}: {
+  events: ActivityEvent[];
+  showProfileColumn: boolean;
+}) {
+  if (events.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Keine Aktivität im gewählten Zeitraum.
+      </p>
+    );
+  }
+
+  return (
+    <div className="border rounded-lg overflow-hidden overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="whitespace-nowrap">Zeitstempel</TableHead>
+            <TableHead>Aktion</TableHead>
+            {showProfileColumn ? <TableHead>Nutzer</TableHead> : null}
+            <TableHead>Turnier</TableHead>
+            <TableHead>Details</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {events.map((event, index) => (
+            <TableRow key={`${event.type}-${event.timestamp.getTime()}-${index}`}>
+              <TableCell className="whitespace-nowrap">
+                {formatEventDateTime(toLocalDateTime(event.timestamp))}
+              </TableCell>
+              <TableCell>
+                <Badge variant="secondary">
+                  {ACTIVITY_EVENT_LABELS[event.type]}
+                </Badge>
+              </TableCell>
+              {showProfileColumn ? (
+                <TableCell>{event.profileName ?? "–"}</TableCell>
+              ) : null}
+              <TableCell>{event.tournamentName ?? "–"}</TableCell>
+              <TableCell className="text-muted-foreground text-sm">
+                {event.detail ?? "–"}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function parseTypes(
+  raw: string | undefined,
+  fallback: ActivityEventType[],
+): ActivityEventType[] {
+  if (!raw) {
+    return fallback;
+  }
+  const requested = raw.split(",");
+  const valid = fallback.filter((type) => requested.includes(type));
+  return valid.length > 0 ? valid : fallback;
+}
+
+function toDateOnlyMinusDays(days: number): string {
+  return parseDateOnly(todayDateOnly()).minus({ days }).toISODate()!;
+}
+
+function startOfDay(dateOnly: string): Date {
+  return parseDateOnly(dateOnly).startOf("day").toJSDate();
+}
+
+function endOfDay(dateOnly: string): Date {
+  return parseDateOnly(dateOnly).endOf("day").toJSDate();
+}

--- a/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
+++ b/src/app/(main)/turniere/[slug]/admin/logging/page.tsx
@@ -55,7 +55,7 @@ export default async function Page({
     <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-gray-900 mb-2">
-          Anmeldungsverlauf
+          Verlauf
         </h1>
         <p className="text-gray-600">
           Konto-, Login- und Anmeldungsaktivität einzelner Nutzer über alle

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Providers } from "./providers";
 import { Toaster } from "@/components/ui/sonner";
 import { Analytics } from "@vercel/analytics/next";
+import { PageViewTracker } from "@/components/page-view-tracker";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -36,6 +37,7 @@ export default function RootLayout({
           </div>
         ) : null}
         <Analytics />
+        <PageViewTracker />
         <Toaster position="top-right" />
         <Providers>{children}</Providers>
       </body>

--- a/src/components/admin/activity-filters.tsx
+++ b/src/components/admin/activity-filters.tsx
@@ -19,13 +19,6 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
   ACTIVITY_EVENT_LABELS,
@@ -36,15 +29,13 @@ import { tournamentPath } from "@/lib/navigation";
 import { useTournamentSlug } from "@/hooks/use-tournament-slug";
 
 type ProfileOption = { id: number; firstName: string; lastName: string };
-type TournamentOption = { id: number; name: string };
 
 type Props = {
   profiles: ProfileOption[];
-  tournaments: TournamentOption[];
   profileId?: number;
-  tournamentId?: number;
   types: ActivityEventType[];
   availableTypes: ActivityEventType[];
+  defaultTypes: ActivityEventType[];
   from?: string;
   fromIsDefault: boolean;
   to?: string;
@@ -52,11 +43,10 @@ type Props = {
 
 export function ActivityFilters({
   profiles,
-  tournaments,
   profileId,
-  tournamentId,
   types,
   availableTypes,
+  defaultTypes,
   from,
   fromIsDefault,
   to,
@@ -69,7 +59,6 @@ export function ActivityFilters({
 
   const buildUrl = (overrides: {
     profileId?: number | null;
-    tournamentId?: number | "all";
     types?: ActivityEventType[];
     from?: string | null;
     to?: string | null;
@@ -78,10 +67,6 @@ export function ActivityFilters({
 
     const nextProfileId =
       overrides.profileId !== undefined ? overrides.profileId : profileId;
-    const nextTournament =
-      overrides.tournamentId !== undefined
-        ? overrides.tournamentId
-        : (tournamentId ?? "all");
     const nextTypes = overrides.types ?? types;
     const nextFrom =
       overrides.from !== undefined ? overrides.from : fromIsDefault ? null : from;
@@ -89,12 +74,8 @@ export function ActivityFilters({
 
     if (nextProfileId) {
       params.set("profileId", String(nextProfileId));
-    } else if (nextTournament === "all") {
-      params.set("tournamentId", "all");
-    } else if (nextTournament != null) {
-      params.set("tournamentId", String(nextTournament));
     }
-    if (nextTypes.length > 0 && nextTypes.length < availableTypes.length) {
+    if (nextTypes.length > 0 && !sameSet(nextTypes, defaultTypes)) {
       params.set("types", nextTypes.join(","));
     }
     if (nextFrom) {
@@ -180,34 +161,6 @@ export function ActivityFilters({
         </Popover>
       </div>
 
-      {profileId == null && tournaments.length > 0 ? (
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="activity-tournament">Turnier</Label>
-          <Select
-            value={tournamentId != null ? String(tournamentId) : "__all__"}
-            onValueChange={(value) =>
-              router.push(
-                buildUrl({
-                  tournamentId: value === "__all__" ? "all" : Number(value),
-                }),
-              )
-            }
-          >
-            <SelectTrigger id="activity-tournament" className="w-56">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__all__">Alle Turniere</SelectItem>
-              {tournaments.map((t) => (
-                <SelectItem key={t.id} value={String(t.id)}>
-                  {t.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      ) : null}
-
       <div className="flex flex-col gap-2">
         <Label id="activity-types-label">Aktionstyp</Label>
         <ToggleGroup
@@ -253,4 +206,8 @@ export function ActivityFilters({
       </div>
     </div>
   );
+}
+
+function sameSet(a: ActivityEventType[], b: ActivityEventType[]) {
+  return a.length === b.length && a.every((item) => b.includes(item));
 }

--- a/src/components/admin/activity-filters.tsx
+++ b/src/components/admin/activity-filters.tsx
@@ -46,6 +46,7 @@ type Props = {
   types: ActivityEventType[];
   availableTypes: ActivityEventType[];
   from?: string;
+  fromIsDefault: boolean;
   to?: string;
 };
 
@@ -57,6 +58,7 @@ export function ActivityFilters({
   types,
   availableTypes,
   from,
+  fromIsDefault,
   to,
 }: Props) {
   const router = useRouter();
@@ -67,7 +69,7 @@ export function ActivityFilters({
 
   const buildUrl = (overrides: {
     profileId?: number | null;
-    tournamentId?: number | null;
+    tournamentId?: number | "all";
     types?: ActivityEventType[];
     from?: string | null;
     to?: string | null;
@@ -76,19 +78,21 @@ export function ActivityFilters({
 
     const nextProfileId =
       overrides.profileId !== undefined ? overrides.profileId : profileId;
-    const nextTournamentId =
+    const nextTournament =
       overrides.tournamentId !== undefined
         ? overrides.tournamentId
-        : tournamentId;
+        : (tournamentId ?? "all");
     const nextTypes = overrides.types ?? types;
-    const nextFrom = overrides.from !== undefined ? overrides.from : from;
+    const nextFrom =
+      overrides.from !== undefined ? overrides.from : fromIsDefault ? null : from;
     const nextTo = overrides.to !== undefined ? overrides.to : to;
 
     if (nextProfileId) {
       params.set("profileId", String(nextProfileId));
-    }
-    if (nextTournamentId) {
-      params.set("tournamentId", String(nextTournamentId));
+    } else if (nextTournament === "all") {
+      params.set("tournamentId", "all");
+    } else if (nextTournament != null) {
+      params.set("tournamentId", String(nextTournament));
     }
     if (nextTypes.length > 0 && nextTypes.length < availableTypes.length) {
       params.set("types", nextTypes.join(","));
@@ -104,13 +108,22 @@ export function ActivityFilters({
     return tournamentPath(slug, `/admin/logging${query ? `?${query}` : ""}`);
   };
 
+  const handleDateBlur = (field: "from" | "to", value: string) => {
+    const current = field === "from" ? from : to;
+    const next = value || null;
+    if ((next ?? "") !== (current ?? "")) {
+      router.push(buildUrl({ [field]: next }));
+    }
+  };
+
   return (
     <div className="flex flex-wrap items-end gap-4">
       <div className="flex flex-col gap-2">
-        <Label>Nutzer</Label>
+        <Label htmlFor="activity-profile">Nutzer</Label>
         <Popover open={profilePickerOpen} onOpenChange={setProfilePickerOpen}>
           <PopoverTrigger asChild>
             <Button
+              id="activity-profile"
               variant="outline"
               role="combobox"
               className="w-64 justify-between"
@@ -169,18 +182,18 @@ export function ActivityFilters({
 
       {profileId == null && tournaments.length > 0 ? (
         <div className="flex flex-col gap-2">
-          <Label>Turnier</Label>
+          <Label htmlFor="activity-tournament">Turnier</Label>
           <Select
-            value={tournamentId ? String(tournamentId) : "__all__"}
+            value={tournamentId != null ? String(tournamentId) : "__all__"}
             onValueChange={(value) =>
               router.push(
                 buildUrl({
-                  tournamentId: value === "__all__" ? null : Number(value),
+                  tournamentId: value === "__all__" ? "all" : Number(value),
                 }),
               )
             }
           >
-            <SelectTrigger className="w-56">
+            <SelectTrigger id="activity-tournament" className="w-56">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -196,10 +209,11 @@ export function ActivityFilters({
       ) : null}
 
       <div className="flex flex-col gap-2">
-        <Label>Aktionstyp</Label>
+        <Label id="activity-types-label">Aktionstyp</Label>
         <ToggleGroup
           type="multiple"
           variant="outline"
+          aria-labelledby="activity-types-label"
           value={types}
           onValueChange={(value) =>
             router.push(buildUrl({ types: value as ActivityEventType[] }))
@@ -220,10 +234,9 @@ export function ActivityFilters({
             id="activity-from"
             type="date"
             className="w-40"
-            value={from ?? ""}
-            onChange={(e) =>
-              router.push(buildUrl({ from: e.target.value || null }))
-            }
+            key={`from-${from ?? ""}`}
+            defaultValue={from ?? ""}
+            onBlur={(e) => handleDateBlur("from", e.target.value)}
           />
         </div>
         <div className="flex flex-col gap-2">
@@ -232,10 +245,9 @@ export function ActivityFilters({
             id="activity-to"
             type="date"
             className="w-40"
-            value={to ?? ""}
-            onChange={(e) =>
-              router.push(buildUrl({ to: e.target.value || null }))
-            }
+            key={`to-${to ?? ""}`}
+            defaultValue={to ?? ""}
+            onBlur={(e) => handleDateBlur("to", e.target.value)}
           />
         </div>
       </div>

--- a/src/components/admin/activity-filters.tsx
+++ b/src/components/admin/activity-filters.tsx
@@ -108,7 +108,7 @@ export function ActivityFilters({
             >
               {selectedProfile
                 ? `${selectedProfile.lastName}, ${selectedProfile.firstName}`
-                : "Alle Nutzer"}
+                : "Nutzer auswählen"}
               <ChevronsUpDown className="h-4 w-4 opacity-50" />
             </Button>
           </PopoverTrigger>
@@ -118,21 +118,6 @@ export function ActivityFilters({
               <CommandList>
                 <CommandEmpty>Keine Treffer</CommandEmpty>
                 <CommandGroup>
-                  <CommandItem
-                    value="__all__"
-                    onSelect={() => {
-                      setProfilePickerOpen(false);
-                      router.push(buildUrl({ profileId: null }));
-                    }}
-                  >
-                    <Check
-                      className={cn(
-                        "mr-2 h-4 w-4",
-                        profileId == null ? "opacity-100" : "opacity-0",
-                      )}
-                    />
-                    Alle Nutzer
-                  </CommandItem>
                   {profiles.map((p) => (
                     <CommandItem
                       key={p.id}

--- a/src/components/admin/activity-filters.tsx
+++ b/src/components/admin/activity-filters.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  ACTIVITY_EVENT_LABELS,
+  type ActivityEventType,
+} from "@/lib/activity";
+import { cn } from "@/lib/utils";
+import { tournamentPath } from "@/lib/navigation";
+import { useTournamentSlug } from "@/hooks/use-tournament-slug";
+
+type ProfileOption = { id: number; firstName: string; lastName: string };
+type TournamentOption = { id: number; name: string };
+
+type Props = {
+  profiles: ProfileOption[];
+  tournaments: TournamentOption[];
+  profileId?: number;
+  tournamentId?: number;
+  types: ActivityEventType[];
+  availableTypes: ActivityEventType[];
+  from?: string;
+  to?: string;
+};
+
+export function ActivityFilters({
+  profiles,
+  tournaments,
+  profileId,
+  tournamentId,
+  types,
+  availableTypes,
+  from,
+  to,
+}: Props) {
+  const router = useRouter();
+  const slug = useTournamentSlug();
+  const [profilePickerOpen, setProfilePickerOpen] = useState(false);
+
+  const selectedProfile = profiles.find((p) => p.id === profileId);
+
+  const buildUrl = (overrides: {
+    profileId?: number | null;
+    tournamentId?: number | null;
+    types?: ActivityEventType[];
+    from?: string | null;
+    to?: string | null;
+  }) => {
+    const params = new URLSearchParams();
+
+    const nextProfileId =
+      overrides.profileId !== undefined ? overrides.profileId : profileId;
+    const nextTournamentId =
+      overrides.tournamentId !== undefined
+        ? overrides.tournamentId
+        : tournamentId;
+    const nextTypes = overrides.types ?? types;
+    const nextFrom = overrides.from !== undefined ? overrides.from : from;
+    const nextTo = overrides.to !== undefined ? overrides.to : to;
+
+    if (nextProfileId) {
+      params.set("profileId", String(nextProfileId));
+    }
+    if (nextTournamentId) {
+      params.set("tournamentId", String(nextTournamentId));
+    }
+    if (nextTypes.length > 0 && nextTypes.length < availableTypes.length) {
+      params.set("types", nextTypes.join(","));
+    }
+    if (nextFrom) {
+      params.set("from", nextFrom);
+    }
+    if (nextTo) {
+      params.set("to", nextTo);
+    }
+
+    const query = params.toString();
+    return tournamentPath(slug, `/admin/logging${query ? `?${query}` : ""}`);
+  };
+
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <div className="flex flex-col gap-2">
+        <Label>Nutzer</Label>
+        <Popover open={profilePickerOpen} onOpenChange={setProfilePickerOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              role="combobox"
+              className="w-64 justify-between"
+            >
+              {selectedProfile
+                ? `${selectedProfile.lastName}, ${selectedProfile.firstName}`
+                : "Alle Nutzer"}
+              <ChevronsUpDown className="h-4 w-4 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-64 p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Nutzer suchen…" />
+              <CommandList>
+                <CommandEmpty>Keine Treffer</CommandEmpty>
+                <CommandGroup>
+                  <CommandItem
+                    value="__all__"
+                    onSelect={() => {
+                      setProfilePickerOpen(false);
+                      router.push(buildUrl({ profileId: null }));
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        profileId == null ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    Alle Nutzer
+                  </CommandItem>
+                  {profiles.map((p) => (
+                    <CommandItem
+                      key={p.id}
+                      value={`${p.lastName} ${p.firstName}`}
+                      onSelect={() => {
+                        setProfilePickerOpen(false);
+                        router.push(buildUrl({ profileId: p.id }));
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4",
+                          profileId === p.id ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      {p.lastName}, {p.firstName}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      {profileId == null && tournaments.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          <Label>Turnier</Label>
+          <Select
+            value={tournamentId ? String(tournamentId) : "__all__"}
+            onValueChange={(value) =>
+              router.push(
+                buildUrl({
+                  tournamentId: value === "__all__" ? null : Number(value),
+                }),
+              )
+            }
+          >
+            <SelectTrigger className="w-56">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">Alle Turniere</SelectItem>
+              {tournaments.map((t) => (
+                <SelectItem key={t.id} value={String(t.id)}>
+                  {t.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        <Label>Aktionstyp</Label>
+        <ToggleGroup
+          type="multiple"
+          variant="outline"
+          value={types}
+          onValueChange={(value) =>
+            router.push(buildUrl({ types: value as ActivityEventType[] }))
+          }
+        >
+          {availableTypes.map((type) => (
+            <ToggleGroupItem key={type} value={type} className="px-3 text-xs">
+              {ACTIVITY_EVENT_LABELS[type]}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+
+      <div className="flex items-end gap-2">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="activity-from">Von</Label>
+          <Input
+            id="activity-from"
+            type="date"
+            className="w-40"
+            value={from ?? ""}
+            onChange={(e) =>
+              router.push(buildUrl({ from: e.target.value || null }))
+            }
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="activity-to">Bis</Label>
+          <Input
+            id="activity-to"
+            type="date"
+            className="w-40"
+            value={to ?? ""}
+            onChange={(e) =>
+              router.push(buildUrl({ to: e.target.value || null }))
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/activity-filters.tsx
+++ b/src/components/admin/activity-filters.tsx
@@ -37,7 +37,6 @@ type Props = {
   availableTypes: ActivityEventType[];
   defaultTypes: ActivityEventType[];
   from?: string;
-  fromIsDefault: boolean;
   to?: string;
 };
 
@@ -48,7 +47,6 @@ export function ActivityFilters({
   availableTypes,
   defaultTypes,
   from,
-  fromIsDefault,
   to,
 }: Props) {
   const router = useRouter();
@@ -68,8 +66,7 @@ export function ActivityFilters({
     const nextProfileId =
       overrides.profileId !== undefined ? overrides.profileId : profileId;
     const nextTypes = overrides.types ?? types;
-    const nextFrom =
-      overrides.from !== undefined ? overrides.from : fromIsDefault ? null : from;
+    const nextFrom = overrides.from !== undefined ? overrides.from : from;
     const nextTo = overrides.to !== undefined ? overrides.to : to;
 
     if (nextProfileId) {
@@ -173,7 +170,11 @@ export function ActivityFilters({
           }
         >
           {availableTypes.map((type) => (
-            <ToggleGroupItem key={type} value={type} className="px-3 text-xs">
+            <ToggleGroupItem
+              key={type}
+              value={type}
+              className="px-3 text-xs data-[state=on]:bg-secondary data-[state=on]:text-secondary-foreground"
+            >
               {ACTIVITY_EVENT_LABELS[type]}
             </ToggleGroupItem>
           ))}

--- a/src/components/admin/activity-table.tsx
+++ b/src/components/admin/activity-table.tsx
@@ -107,12 +107,7 @@ export function ActivityTable({ events }: Props) {
                     </Badge>
                   </TableCell>
                   <TableCell className="text-sm text-muted-foreground">
-                    {event.path ??
-                      (isExpandable
-                        ? `${Object.keys(event.changes!).length} Feld${
-                            Object.keys(event.changes!).length === 1 ? "" : "er"
-                          } geändert`
-                        : "–")}
+                    {eventDetail(event)}
                   </TableCell>
                 </TableRow>
                 {isExpandable && isExpanded ? (
@@ -142,6 +137,22 @@ export function ActivityTable({ events }: Props) {
       </Table>
     </div>
   );
+}
+
+function eventDetail(event: ActivityEvent): string {
+  if (event.path) {
+    return event.path;
+  }
+
+  const parts: string[] = [];
+  if (event.tournamentName) {
+    parts.push(event.tournamentName);
+  }
+  if (event.changes != null) {
+    const count = Object.keys(event.changes).length;
+    parts.push(`${count} Feld${count === 1 ? "" : "er"} geändert`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : "–";
 }
 
 function formatValue(field: string, value: unknown): string {

--- a/src/components/admin/activity-table.tsx
+++ b/src/components/admin/activity-table.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { Fragment, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import {
+  ACTIVITY_EVENT_LABELS,
+  type ActivityEvent,
+} from "@/lib/activity";
+import { formatDateOnly, formatEventDateTime, toLocalDateTime } from "@/lib/date";
+import { matchDays } from "@/constants/constants";
+import { DayOfWeek } from "@/db/types/group";
+
+const FIELD_LABELS: Record<string, string> = {
+  chessClub: "Schachverein",
+  title: "Titel",
+  gender: "Geschlecht",
+  dwzRating: "DWZ",
+  fideRating: "Elo",
+  fideId: "FIDE ID",
+  nationality: "Nationalität",
+  birthYear: "Geburtsjahr",
+  birthDate: "Geburtsdatum",
+  preferredMatchDay: "Bevorzugter Spieltag",
+  secondaryMatchDays: "Ausweich-Spieltage",
+  notAvailableDays: "Nicht verfügbare Tage",
+  dsbPersonId: "DSB-Person",
+  zpsClubId: "ZPS-Verein",
+  zpsPlayerId: "ZPS-Spieler",
+  entryFeePayed: "Startgeld bezahlt",
+  exercisePromotionRight: "Aufstiegsrecht",
+};
+
+type Props = {
+  events: ActivityEvent[];
+};
+
+export function ActivityTable({ events }: Props) {
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+
+  if (events.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Keine Aktivität im gewählten Zeitraum.
+      </p>
+    );
+  }
+
+  const toggleRow = (index: number) => {
+    setExpandedRows((current) => {
+      const next = new Set(current);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="border rounded-lg overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-8" />
+            <TableHead className="whitespace-nowrap">Zeitstempel</TableHead>
+            <TableHead>Aktion</TableHead>
+            <TableHead>Details</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {events.map((event, index) => {
+            const isExpandable =
+              event.changes != null && Object.keys(event.changes).length > 0;
+            const isExpanded = expandedRows.has(index);
+
+            return (
+              <Fragment key={`${event.type}-${event.timestamp.getTime()}-${index}`}>
+                <TableRow
+                  className={isExpandable ? "cursor-pointer" : undefined}
+                  onClick={isExpandable ? () => toggleRow(index) : undefined}
+                >
+                  <TableCell className="w-8">
+                    {isExpandable ? (
+                      isExpanded ? (
+                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                      )
+                    ) : null}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap">
+                    {formatEventDateTime(toLocalDateTime(event.timestamp))}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">
+                      {ACTIVITY_EVENT_LABELS[event.type]}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {event.path ??
+                      (isExpandable
+                        ? `${Object.keys(event.changes!).length} Feld${
+                            Object.keys(event.changes!).length === 1 ? "" : "er"
+                          } geändert`
+                        : "–")}
+                  </TableCell>
+                </TableRow>
+                {isExpandable && isExpanded ? (
+                  <TableRow className="bg-muted/40 hover:bg-muted/40">
+                    <TableCell />
+                    <TableCell colSpan={3}>
+                      <dl className="space-y-1 py-1 text-sm">
+                        {Object.entries(event.changes!).map(([field, change]) => (
+                          <div key={field} className="flex flex-wrap gap-x-2">
+                            <dt className="font-medium">
+                              {FIELD_LABELS[field] ?? field}:
+                            </dt>
+                            <dd className="text-muted-foreground">
+                              {formatValue(field, change.old)} →{" "}
+                              {formatValue(field, change.new)}
+                            </dd>
+                          </div>
+                        ))}
+                      </dl>
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+              </Fragment>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function formatValue(field: string, value: unknown): string {
+  if (value == null || (Array.isArray(value) && value.length === 0)) {
+    return "–";
+  }
+  if (typeof value === "boolean") {
+    return value ? "Ja" : "Nein";
+  }
+  if (field === "preferredMatchDay") {
+    return matchDays[value as DayOfWeek] ?? String(value);
+  }
+  if (field === "secondaryMatchDays" && Array.isArray(value)) {
+    return value
+      .map((day) => matchDays[day as DayOfWeek] ?? String(day))
+      .join(", ");
+  }
+  if (field === "notAvailableDays" && Array.isArray(value)) {
+    return value.map((day) => formatDateOnly(String(day))).join(", ");
+  }
+  if (field === "birthDate") {
+    return formatDateOnly(String(value));
+  }
+  if (field === "gender") {
+    return value === "m" ? "Männlich" : "Weiblich";
+  }
+  return String(value);
+}

--- a/src/components/admin/user-row.tsx
+++ b/src/components/admin/user-row.tsx
@@ -195,22 +195,24 @@ export function UserRow({
       </div>
       <div className="flex items-center gap-2">
         <div className="text-xs text-gray-500">ID: {user.id}</div>
-        <Button
-          asChild
-          variant="outline"
-          size="sm"
-          className="h-7 w-7 p-0"
-          title="Verlauf ansehen"
-        >
-          <Link
-            href={tournamentPath(
-              slug,
-              `/admin/logging?profileId=${user.id}`,
-            )}
+        {user.deletedAt == null ? (
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="h-7 w-7 p-0"
+            title="Verlauf ansehen"
           >
-            <History className="h-4 w-4" />
-          </Link>
-        </Button>
+            <Link
+              href={tournamentPath(
+                slug,
+                `/admin/logging?profileId=${user.id}`,
+              )}
+            >
+              <History className="h-4 w-4" />
+            </Link>
+          </Button>
+        ) : null}
         {user.deletedAt != null ? (
           <Button
             variant="outline"

--- a/src/components/admin/user-row.tsx
+++ b/src/components/admin/user-row.tsx
@@ -18,7 +18,11 @@ import {
   Phone,
   Mail,
   Volleyball,
+  History,
 } from "lucide-react";
+import Link from "next/link";
+import { tournamentPath } from "@/lib/navigation";
+import { useTournamentSlug } from "@/hooks/use-tournament-slug";
 import { useState, useTransition } from "react";
 import {
   softDeleteUserProfile,
@@ -48,6 +52,7 @@ export function UserRow({
   const [softDeleteOpen, setSoftDeleteOpen] = useState(false);
   const [hardDeleteOpen, setHardDeleteOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const slug = useTournamentSlug();
 
   const getDisplayName = (user: ProfileWithName) => {
     return `${user.firstName} ${user.lastName}`;
@@ -190,6 +195,22 @@ export function UserRow({
       </div>
       <div className="flex items-center gap-2">
         <div className="text-xs text-gray-500">ID: {user.id}</div>
+        <Button
+          asChild
+          variant="outline"
+          size="sm"
+          className="h-7 w-7 p-0"
+          title="Verlauf ansehen"
+        >
+          <Link
+            href={tournamentPath(
+              slug,
+              `/admin/logging?profileId=${user.id}`,
+            )}
+          >
+            <History className="h-4 w-4" />
+          </Link>
+        </Button>
         {user.deletedAt != null ? (
           <Button
             variant="outline"

--- a/src/components/klubturnier-anmeldung/forms/participant-form.tsx
+++ b/src/components/klubturnier-anmeldung/forms/participant-form.tsx
@@ -64,6 +64,7 @@ import {
 } from "@/constants/constants";
 import { Switch } from "@/components/ui/switch";
 import type { PromotionEligibility } from "@/services/promotion";
+import { track } from "@vercel/analytics";
 
 type Props = {
   initialValues?: z.infer<typeof participantFormSchema>;
@@ -178,12 +179,14 @@ export function ParticipateForm({
   };
 
   const handleSubmit = (data: z.infer<typeof participantFormSchema>) => {
+    track("participant_form_submit", { tournamentId: tournament.id });
     startTransition(async () => {
       await onSubmit(data);
     });
   };
 
   const handleDelete = () => {
+    track("participant_delete_click", { tournamentId: tournament.id });
     startTransition(async () => {
       await onDelete();
     });

--- a/src/components/klubturnier-anmeldung/roles-manager.tsx
+++ b/src/components/klubturnier-anmeldung/roles-manager.tsx
@@ -91,7 +91,14 @@ export function RolesManager({
 
   const handleDeleteParticipant = async () => {
     if (rolesData.participant) {
-      await deleteParticipant(tournament.id, rolesData.participant.id);
+      const result = await deleteParticipant(
+        tournament.id,
+        rolesData.participant.id,
+      );
+      if (isError(result)) {
+        toast.error("Deine Anmeldung konnte nicht gelöscht werden.");
+        return;
+      }
       router.refresh();
     }
   };

--- a/src/components/page-view-tracker.tsx
+++ b/src/components/page-view-tracker.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { logPageView } from "@/actions/page-view";
+
+export function PageViewTracker() {
+  const pathname = usePathname();
+  const lastLoggedPath = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (pathname && lastLoggedPath.current !== pathname) {
+      lastLoggedPath.current = pathname;
+      void logPageView(pathname);
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   CalendarIcon,
   Euro,
   FileCheck,
+  HistoryIcon,
   LayoutDashboard,
   Medal,
   SwordsIcon,
@@ -225,6 +226,12 @@ export function AppSidebar({ session, tournaments, userRoles, documentAvailabili
                 icon={UserRoundCogIcon}
               >
                 Nutzer verwalten
+              </SidebarLink>
+              <SidebarLink
+                href={tournamentPath(slug, "/admin/logging")}
+                icon={HistoryIcon}
+              >
+                Anmeldungsverlauf
               </SidebarLink>
               <SidebarLink
                 href={tournamentPath(slug, "/admin/gruppen")}

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -231,7 +231,7 @@ export function AppSidebar({ session, tournaments, userRoles, documentAvailabili
                 href={tournamentPath(slug, "/admin/logging")}
                 icon={HistoryIcon}
               >
-                Anmeldungsverlauf
+                Verlauf
               </SidebarLink>
               <SidebarLink
                 href={tournamentPath(slug, "/admin/gruppen")}

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -15,6 +15,8 @@ import * as trainerSchema from "./schema/trainer";
 import * as matchEnteringHelperSchema from "./schema/matchEnteringHelper";
 import * as matchdaySchema from "./schema/matchday";
 import * as gamePostponementSchema from "./schema/gamePostponement";
+import * as participantChangeLogSchema from "./schema/participantChangeLog";
+import * as pageViewSchema from "./schema/pageView";
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL! });
 
@@ -35,5 +37,7 @@ export const db = drizzle(pool, {
     ...matchEnteringHelperSchema,
     ...matchdaySchema,
     ...gamePostponementSchema,
+    ...participantChangeLogSchema,
+    ...pageViewSchema,
   },
 });

--- a/src/db/repositories/activity.ts
+++ b/src/db/repositories/activity.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, lte } from "drizzle-orm";
+import { and, desc, eq, gte, isNull, lte } from "drizzle-orm";
 import { db } from "../client";
 import { session } from "../schema/auth";
 import { profile } from "../schema/profile";
@@ -37,7 +37,7 @@ export async function getActivityTimelineForProfile(
   filter: ActivityFilter = {},
 ): Promise<ActivityEvent[]> {
   const profileRow = await db.query.profile.findFirst({
-    where: eq(profile.id, profileId),
+    where: and(eq(profile.id, profileId), isNull(profile.deletedAt)),
     columns: { userId: true, createdAt: true },
   });
 
@@ -56,7 +56,7 @@ export async function getActivityTimelineForProfile(
             filter.from ? gte(session.createdAt, filter.from) : undefined,
             filter.to ? lte(session.createdAt, filter.to) : undefined,
           ),
-          columns: { createdAt: true, ipAddress: true, userAgent: true },
+          columns: { createdAt: true },
         })
       : Promise.resolve([]),
     wantsParticipants
@@ -71,7 +71,12 @@ export async function getActivityTimelineForProfile(
           // a row can be relevant via either its create or its update
           // timestamp, so the date filter is applied per-event below
           // instead of narrowing this query
-          .where(eq(participant.profileId, profileId))
+          .where(
+            and(
+              eq(participant.profileId, profileId),
+              isNull(participant.deletedAt),
+            ),
+          )
       : Promise.resolve([]),
   ]);
 
@@ -88,7 +93,9 @@ export async function getActivityTimelineForProfile(
 
 export async function getRecentParticipantActivity(
   filter: ActivityFilter & { tournamentId?: number; limit?: number } = {},
-): Promise<ActivityEvent[]> {
+): Promise<{ events: ActivityEvent[]; truncated: boolean }> {
+  const limit = filter.limit ?? DEFAULT_RECENT_LIMIT;
+
   const rows = await db
     .select({
       createdAt: participant.createdAt,
@@ -102,19 +109,25 @@ export async function getRecentParticipantActivity(
     .innerJoin(profile, eq(participant.profileId, profile.id))
     .where(
       and(
+        isNull(participant.deletedAt),
+        isNull(profile.deletedAt),
         filter.tournamentId
           ? eq(participant.tournamentId, filter.tournamentId)
           : undefined,
         filter.from ? gte(participant.updatedAt, filter.from) : undefined,
-        filter.to ? lte(participant.updatedAt, filter.to) : undefined,
+        // bound by createdAt, not updatedAt: a row edited after "to" must
+        // still contribute its in-range "registered" event
+        filter.to ? lte(participant.createdAt, filter.to) : undefined,
       ),
     )
     .orderBy(desc(participant.updatedAt))
-    .limit(filter.limit ?? DEFAULT_RECENT_LIMIT);
+    .limit(limit + 1);
 
-  return buildActivityTimeline({
+  const truncated = rows.length > limit;
+
+  const events = buildActivityTimeline({
     sessions: [],
-    participants: rows.map((r) => ({
+    participants: rows.slice(0, limit).map((r) => ({
       createdAt: r.createdAt,
       updatedAt: r.updatedAt,
       tournamentName: r.tournamentName,
@@ -123,4 +136,6 @@ export async function getRecentParticipantActivity(
   }).filter(
     (event) => wants(filter.types, event.type) && inRange(event.timestamp, filter),
   );
+
+  return { events, truncated };
 }

--- a/src/db/repositories/activity.ts
+++ b/src/db/repositories/activity.ts
@@ -1,20 +1,25 @@
 import { and, desc, eq, gte, isNull, lte } from "drizzle-orm";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import { db } from "../client";
 import { session } from "../schema/auth";
 import { profile } from "../schema/profile";
 import { participant } from "../schema/participant";
+import { participantChangeLog } from "../schema/participantChangeLog";
+import { pageView } from "../schema/pageView";
 import {
   buildActivityTimeline,
   type ActivityEvent,
   type ActivityEventType,
 } from "@/lib/activity";
 
-const DEFAULT_RECENT_LIMIT = 200;
+const DEFAULT_LIMIT = 200;
 
 type ActivityFilter = {
   from?: Date;
   to?: Date;
   types?: ActivityEventType[];
+  tournamentId?: number;
+  limit?: number;
 };
 
 function wants(types: ActivityEventType[] | undefined, type: ActivityEventType) {
@@ -33,41 +38,40 @@ function inRange(date: Date, filter: ActivityFilter) {
 
 export async function getActivityTimelineForProfile(
   profileId: number,
-  filter: ActivityFilter & { tournamentId?: number } = {},
-): Promise<ActivityEvent[]> {
+  filter: ActivityFilter = {},
+): Promise<{ events: ActivityEvent[]; truncated: boolean }> {
+  const limit = filter.limit ?? DEFAULT_LIMIT;
+
   const profileRow = await db.query.profile.findFirst({
     where: and(eq(profile.id, profileId), isNull(profile.deletedAt)),
     columns: { userId: true, createdAt: true },
   });
 
   if (!profileRow) {
-    return [];
+    return { events: [], truncated: false };
   }
 
-  const wantsParticipants =
-    wants(filter.types, "registered") || wants(filter.types, "updated");
+  const dateBounds = (column: AnyPgColumn) =>
+    and(
+      filter.from ? gte(column, filter.from) : undefined,
+      filter.to ? lte(column, filter.to) : undefined,
+    );
 
-  const [sessions, participants] = await Promise.all([
+  const [sessions, registrations, changes, pageViews] = await Promise.all([
     wants(filter.types, "login")
-      ? db.query.session.findMany({
-          where: and(
-            eq(session.userId, profileRow.userId),
-            filter.from ? gte(session.createdAt, filter.from) : undefined,
-            filter.to ? lte(session.createdAt, filter.to) : undefined,
-          ),
-          columns: { createdAt: true },
-        })
-      : Promise.resolve([]),
-    wantsParticipants
       ? db
-          .select({
-            createdAt: participant.createdAt,
-            updatedAt: participant.updatedAt,
-          })
+          .select({ createdAt: session.createdAt })
+          .from(session)
+          .where(
+            and(eq(session.userId, profileRow.userId), dateBounds(session.createdAt)),
+          )
+          .orderBy(desc(session.createdAt))
+          .limit(limit + 1)
+      : Promise.resolve([]),
+    wants(filter.types, "registered")
+      ? db
+          .select({ createdAt: participant.createdAt })
           .from(participant)
-          // a row can be relevant via either its create or its update
-          // timestamp, so the date filter is applied per-event below
-          // instead of narrowing this query
           .where(
             and(
               eq(participant.profileId, profileId),
@@ -75,110 +79,58 @@ export async function getActivityTimelineForProfile(
               filter.tournamentId
                 ? eq(participant.tournamentId, filter.tournamentId)
                 : undefined,
+              dateBounds(participant.createdAt),
             ),
           )
       : Promise.resolve([]),
-  ]);
-
-  return buildActivityTimeline({
-    accounts: [{ createdAt: profileRow.createdAt }],
-    sessions,
-    participants,
-  }).filter(
-    (event) => wants(filter.types, event.type) && inRange(event.timestamp, filter),
-  );
-}
-
-export async function getRecentActivity(
-  filter: ActivityFilter & { tournamentId?: number; limit?: number } = {},
-): Promise<{ events: ActivityEvent[]; truncated: boolean }> {
-  const limit = filter.limit ?? DEFAULT_RECENT_LIMIT;
-
-  const wantsParticipants =
-    wants(filter.types, "registered") || wants(filter.types, "updated");
-
-  const [participantRows, sessionRows, accountRows] = await Promise.all([
-    wantsParticipants
+    wants(filter.types, "updated")
       ? db
           .select({
-            createdAt: participant.createdAt,
-            updatedAt: participant.updatedAt,
-            firstName: profile.firstName,
-            lastName: profile.lastName,
+            createdAt: participantChangeLog.createdAt,
+            changes: participantChangeLog.changes,
           })
-          .from(participant)
-          .innerJoin(profile, eq(participant.profileId, profile.id))
+          .from(participantChangeLog)
           .where(
             and(
-              isNull(participant.deletedAt),
-              isNull(profile.deletedAt),
+              eq(participantChangeLog.profileId, profileId),
               filter.tournamentId
-                ? eq(participant.tournamentId, filter.tournamentId)
+                ? eq(participantChangeLog.tournamentId, filter.tournamentId)
                 : undefined,
-              filter.from ? gte(participant.updatedAt, filter.from) : undefined,
-              // bound by createdAt, not updatedAt: a row edited after "to"
-              // must still contribute its in-range "registered" event
-              filter.to ? lte(participant.createdAt, filter.to) : undefined,
+              dateBounds(participantChangeLog.createdAt),
             ),
           )
-          .orderBy(desc(participant.updatedAt))
+          .orderBy(desc(participantChangeLog.createdAt))
           .limit(limit + 1)
       : Promise.resolve([]),
-    wants(filter.types, "login")
+    wants(filter.types, "page_view")
       ? db
-          .select({
-            createdAt: session.createdAt,
-            firstName: profile.firstName,
-            lastName: profile.lastName,
-          })
-          .from(session)
-          .innerJoin(profile, eq(session.userId, profile.userId))
+          .select({ createdAt: pageView.createdAt, path: pageView.path })
+          .from(pageView)
           .where(
             and(
-              isNull(profile.deletedAt),
-              filter.from ? gte(session.createdAt, filter.from) : undefined,
-              filter.to ? lte(session.createdAt, filter.to) : undefined,
+              eq(pageView.userId, profileRow.userId),
+              dateBounds(pageView.createdAt),
             ),
           )
-          .orderBy(desc(session.createdAt))
-          .limit(limit + 1)
-      : Promise.resolve([]),
-    wants(filter.types, "account_created")
-      ? db
-          .select({
-            createdAt: profile.createdAt,
-            firstName: profile.firstName,
-            lastName: profile.lastName,
-          })
-          .from(profile)
-          .where(
-            and(
-              isNull(profile.deletedAt),
-              filter.from ? gte(profile.createdAt, filter.from) : undefined,
-              filter.to ? lte(profile.createdAt, filter.to) : undefined,
-            ),
-          )
-          .orderBy(desc(profile.createdAt))
+          .orderBy(desc(pageView.createdAt))
           .limit(limit + 1)
       : Promise.resolve([]),
   ]);
 
   const truncated =
-    participantRows.length > limit ||
-    sessionRows.length > limit ||
-    accountRows.length > limit;
-
-  const withName = <T extends { firstName: string; lastName: string }>(
-    row: T,
-  ) => ({ ...row, profileName: `${row.firstName} ${row.lastName}` });
+    sessions.length > limit ||
+    changes.length > limit ||
+    pageViews.length > limit;
 
   const events = buildActivityTimeline({
-    accounts: accountRows.slice(0, limit).map(withName),
-    sessions: sessionRows.slice(0, limit).map(withName),
-    participants: participantRows.slice(0, limit).map(withName),
-  }).filter(
-    (event) => wants(filter.types, event.type) && inRange(event.timestamp, filter),
-  );
+    accounts: wants(filter.types, "account_created")
+      ? [{ createdAt: profileRow.createdAt }]
+      : [],
+    sessions: sessions.slice(0, limit),
+    registrations,
+    changes: changes.slice(0, limit),
+    pageViews: pageViews.slice(0, limit),
+  }).filter((event) => inRange(event.timestamp, filter));
 
   return { events, truncated };
 }

--- a/src/db/repositories/activity.ts
+++ b/src/db/repositories/activity.ts
@@ -6,6 +6,7 @@ import { profile } from "../schema/profile";
 import { participant } from "../schema/participant";
 import { participantChangeLog } from "../schema/participantChangeLog";
 import { pageView } from "../schema/pageView";
+import { tournament } from "../schema/tournament";
 import {
   buildActivityTimeline,
   type ActivityEvent,
@@ -18,7 +19,6 @@ type ActivityFilter = {
   from?: Date;
   to?: Date;
   types?: ActivityEventType[];
-  tournamentId?: number;
   limit?: number;
 };
 
@@ -70,15 +70,16 @@ export async function getActivityTimelineForProfile(
       : Promise.resolve([]),
     wants(filter.types, "registered")
       ? db
-          .select({ createdAt: participant.createdAt })
+          .select({
+            createdAt: participant.createdAt,
+            tournamentName: tournament.name,
+          })
           .from(participant)
+          .innerJoin(tournament, eq(participant.tournamentId, tournament.id))
           .where(
             and(
               eq(participant.profileId, profileId),
               isNull(participant.deletedAt),
-              filter.tournamentId
-                ? eq(participant.tournamentId, filter.tournamentId)
-                : undefined,
               dateBounds(participant.createdAt),
             ),
           )
@@ -88,14 +89,16 @@ export async function getActivityTimelineForProfile(
           .select({
             createdAt: participantChangeLog.createdAt,
             changes: participantChangeLog.changes,
+            tournamentName: tournament.name,
           })
           .from(participantChangeLog)
+          .innerJoin(
+            tournament,
+            eq(participantChangeLog.tournamentId, tournament.id),
+          )
           .where(
             and(
               eq(participantChangeLog.profileId, profileId),
-              filter.tournamentId
-                ? eq(participantChangeLog.tournamentId, filter.tournamentId)
-                : undefined,
               dateBounds(participantChangeLog.createdAt),
             ),
           )

--- a/src/db/repositories/activity.ts
+++ b/src/db/repositories/activity.ts
@@ -1,0 +1,126 @@
+import { and, desc, eq, gte, lte } from "drizzle-orm";
+import { db } from "../client";
+import { session } from "../schema/auth";
+import { profile } from "../schema/profile";
+import { participant } from "../schema/participant";
+import { tournament } from "../schema/tournament";
+import {
+  buildActivityTimeline,
+  type ActivityEvent,
+  type ActivityEventType,
+} from "@/lib/activity";
+
+const DEFAULT_RECENT_LIMIT = 200;
+
+type ActivityFilter = {
+  from?: Date;
+  to?: Date;
+  types?: ActivityEventType[];
+};
+
+function wants(types: ActivityEventType[] | undefined, type: ActivityEventType) {
+  return types == null || types.includes(type);
+}
+
+function inRange(date: Date, filter: ActivityFilter) {
+  if (filter.from && date < filter.from) {
+    return false;
+  }
+  if (filter.to && date > filter.to) {
+    return false;
+  }
+  return true;
+}
+
+export async function getActivityTimelineForProfile(
+  profileId: number,
+  filter: ActivityFilter = {},
+): Promise<ActivityEvent[]> {
+  const profileRow = await db.query.profile.findFirst({
+    where: eq(profile.id, profileId),
+    columns: { userId: true, createdAt: true },
+  });
+
+  if (!profileRow) {
+    return [];
+  }
+
+  const wantsParticipants =
+    wants(filter.types, "registered") || wants(filter.types, "updated");
+
+  const [sessions, participants] = await Promise.all([
+    wants(filter.types, "login")
+      ? db.query.session.findMany({
+          where: and(
+            eq(session.userId, profileRow.userId),
+            filter.from ? gte(session.createdAt, filter.from) : undefined,
+            filter.to ? lte(session.createdAt, filter.to) : undefined,
+          ),
+          columns: { createdAt: true, ipAddress: true, userAgent: true },
+        })
+      : Promise.resolve([]),
+    wantsParticipants
+      ? db
+          .select({
+            createdAt: participant.createdAt,
+            updatedAt: participant.updatedAt,
+            tournamentName: tournament.name,
+          })
+          .from(participant)
+          .innerJoin(tournament, eq(participant.tournamentId, tournament.id))
+          // a row can be relevant via either its create or its update
+          // timestamp, so the date filter is applied per-event below
+          // instead of narrowing this query
+          .where(eq(participant.profileId, profileId))
+      : Promise.resolve([]),
+  ]);
+
+  return buildActivityTimeline({
+    accountCreatedAt: wants(filter.types, "account_created")
+      ? profileRow.createdAt
+      : null,
+    sessions,
+    participants,
+  }).filter(
+    (event) => wants(filter.types, event.type) && inRange(event.timestamp, filter),
+  );
+}
+
+export async function getRecentParticipantActivity(
+  filter: ActivityFilter & { tournamentId?: number; limit?: number } = {},
+): Promise<ActivityEvent[]> {
+  const rows = await db
+    .select({
+      createdAt: participant.createdAt,
+      updatedAt: participant.updatedAt,
+      tournamentName: tournament.name,
+      firstName: profile.firstName,
+      lastName: profile.lastName,
+    })
+    .from(participant)
+    .innerJoin(tournament, eq(participant.tournamentId, tournament.id))
+    .innerJoin(profile, eq(participant.profileId, profile.id))
+    .where(
+      and(
+        filter.tournamentId
+          ? eq(participant.tournamentId, filter.tournamentId)
+          : undefined,
+        filter.from ? gte(participant.updatedAt, filter.from) : undefined,
+        filter.to ? lte(participant.updatedAt, filter.to) : undefined,
+      ),
+    )
+    .orderBy(desc(participant.updatedAt))
+    .limit(filter.limit ?? DEFAULT_RECENT_LIMIT);
+
+  return buildActivityTimeline({
+    sessions: [],
+    participants: rows.map((r) => ({
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+      tournamentName: r.tournamentName,
+      profileName: `${r.firstName} ${r.lastName}`,
+    })),
+  }).filter(
+    (event) => wants(filter.types, event.type) && inRange(event.timestamp, filter),
+  );
+}

--- a/src/db/repositories/activity.ts
+++ b/src/db/repositories/activity.ts
@@ -26,6 +26,14 @@ function wants(types: ActivityEventType[] | undefined, type: ActivityEventType) 
   return types == null || types.includes(type);
 }
 
+function when<T>(
+  types: ActivityEventType[] | undefined,
+  type: ActivityEventType,
+  run: () => Promise<T[]>,
+): Promise<T[]> {
+  return wants(types, type) ? run() : Promise.resolve([]);
+}
+
 function inRange(date: Date, filter: ActivityFilter) {
   if (filter.from && date < filter.from) {
     return false;
@@ -58,66 +66,66 @@ export async function getActivityTimelineForProfile(
     );
 
   const [sessions, registrations, changes, pageViews] = await Promise.all([
-    wants(filter.types, "login")
-      ? db
-          .select({ createdAt: session.createdAt })
-          .from(session)
-          .where(
-            and(eq(session.userId, profileRow.userId), dateBounds(session.createdAt)),
-          )
-          .orderBy(desc(session.createdAt))
-          .limit(limit + 1)
-      : Promise.resolve([]),
-    wants(filter.types, "registered")
-      ? db
-          .select({
-            createdAt: participant.createdAt,
-            tournamentName: tournament.name,
-          })
-          .from(participant)
-          .innerJoin(tournament, eq(participant.tournamentId, tournament.id))
-          .where(
-            and(
-              eq(participant.profileId, profileId),
-              isNull(participant.deletedAt),
-              dateBounds(participant.createdAt),
-            ),
-          )
-      : Promise.resolve([]),
-    wants(filter.types, "updated")
-      ? db
-          .select({
-            createdAt: participantChangeLog.createdAt,
-            changes: participantChangeLog.changes,
-            tournamentName: tournament.name,
-          })
-          .from(participantChangeLog)
-          .innerJoin(
-            tournament,
-            eq(participantChangeLog.tournamentId, tournament.id),
-          )
-          .where(
-            and(
-              eq(participantChangeLog.profileId, profileId),
-              dateBounds(participantChangeLog.createdAt),
-            ),
-          )
-          .orderBy(desc(participantChangeLog.createdAt))
-          .limit(limit + 1)
-      : Promise.resolve([]),
-    wants(filter.types, "page_view")
-      ? db
-          .select({ createdAt: pageView.createdAt, path: pageView.path })
-          .from(pageView)
-          .where(
-            and(
-              eq(pageView.userId, profileRow.userId),
-              dateBounds(pageView.createdAt),
-            ),
-          )
-          .orderBy(desc(pageView.createdAt))
-          .limit(limit + 1)
-      : Promise.resolve([]),
+    when(filter.types, "login", () =>
+      db
+        .select({ createdAt: session.createdAt })
+        .from(session)
+        .where(
+          and(eq(session.userId, profileRow.userId), dateBounds(session.createdAt)),
+        )
+        .orderBy(desc(session.createdAt))
+        .limit(limit + 1),
+    ),
+    when(filter.types, "registered", () =>
+      db
+        .select({
+          createdAt: participant.createdAt,
+          tournamentName: tournament.name,
+        })
+        .from(participant)
+        .innerJoin(tournament, eq(participant.tournamentId, tournament.id))
+        .where(
+          and(
+            eq(participant.profileId, profileId),
+            isNull(participant.deletedAt),
+            dateBounds(participant.createdAt),
+          ),
+        ),
+    ),
+    when(filter.types, "updated", () =>
+      db
+        .select({
+          createdAt: participantChangeLog.createdAt,
+          changes: participantChangeLog.changes,
+          tournamentName: tournament.name,
+        })
+        .from(participantChangeLog)
+        .innerJoin(
+          tournament,
+          eq(participantChangeLog.tournamentId, tournament.id),
+        )
+        .where(
+          and(
+            eq(participantChangeLog.profileId, profileId),
+            dateBounds(participantChangeLog.createdAt),
+          ),
+        )
+        .orderBy(desc(participantChangeLog.createdAt))
+        .limit(limit + 1),
+    ),
+    when(filter.types, "page_view", () =>
+      db
+        .select({ createdAt: pageView.createdAt, path: pageView.path })
+        .from(pageView)
+        .where(
+          and(
+            eq(pageView.userId, profileRow.userId),
+            dateBounds(pageView.createdAt),
+          ),
+        )
+        .orderBy(desc(pageView.createdAt))
+        .limit(limit + 1),
+    ),
   ]);
 
   const truncated =

--- a/src/db/repositories/activity.ts
+++ b/src/db/repositories/activity.ts
@@ -3,7 +3,6 @@ import { db } from "../client";
 import { session } from "../schema/auth";
 import { profile } from "../schema/profile";
 import { participant } from "../schema/participant";
-import { tournament } from "../schema/tournament";
 import {
   buildActivityTimeline,
   type ActivityEvent,
@@ -34,7 +33,7 @@ function inRange(date: Date, filter: ActivityFilter) {
 
 export async function getActivityTimelineForProfile(
   profileId: number,
-  filter: ActivityFilter = {},
+  filter: ActivityFilter & { tournamentId?: number } = {},
 ): Promise<ActivityEvent[]> {
   const profileRow = await db.query.profile.findFirst({
     where: and(eq(profile.id, profileId), isNull(profile.deletedAt)),
@@ -64,10 +63,8 @@ export async function getActivityTimelineForProfile(
           .select({
             createdAt: participant.createdAt,
             updatedAt: participant.updatedAt,
-            tournamentName: tournament.name,
           })
           .from(participant)
-          .innerJoin(tournament, eq(participant.tournamentId, tournament.id))
           // a row can be relevant via either its create or its update
           // timestamp, so the date filter is applied per-event below
           // instead of narrowing this query
@@ -75,15 +72,16 @@ export async function getActivityTimelineForProfile(
             and(
               eq(participant.profileId, profileId),
               isNull(participant.deletedAt),
+              filter.tournamentId
+                ? eq(participant.tournamentId, filter.tournamentId)
+                : undefined,
             ),
           )
       : Promise.resolve([]),
   ]);
 
   return buildActivityTimeline({
-    accountCreatedAt: wants(filter.types, "account_created")
-      ? profileRow.createdAt
-      : null,
+    accounts: [{ createdAt: profileRow.createdAt }],
     sessions,
     participants,
   }).filter(
@@ -91,48 +89,93 @@ export async function getActivityTimelineForProfile(
   );
 }
 
-export async function getRecentParticipantActivity(
+export async function getRecentActivity(
   filter: ActivityFilter & { tournamentId?: number; limit?: number } = {},
 ): Promise<{ events: ActivityEvent[]; truncated: boolean }> {
   const limit = filter.limit ?? DEFAULT_RECENT_LIMIT;
 
-  const rows = await db
-    .select({
-      createdAt: participant.createdAt,
-      updatedAt: participant.updatedAt,
-      tournamentName: tournament.name,
-      firstName: profile.firstName,
-      lastName: profile.lastName,
-    })
-    .from(participant)
-    .innerJoin(tournament, eq(participant.tournamentId, tournament.id))
-    .innerJoin(profile, eq(participant.profileId, profile.id))
-    .where(
-      and(
-        isNull(participant.deletedAt),
-        isNull(profile.deletedAt),
-        filter.tournamentId
-          ? eq(participant.tournamentId, filter.tournamentId)
-          : undefined,
-        filter.from ? gte(participant.updatedAt, filter.from) : undefined,
-        // bound by createdAt, not updatedAt: a row edited after "to" must
-        // still contribute its in-range "registered" event
-        filter.to ? lte(participant.createdAt, filter.to) : undefined,
-      ),
-    )
-    .orderBy(desc(participant.updatedAt))
-    .limit(limit + 1);
+  const wantsParticipants =
+    wants(filter.types, "registered") || wants(filter.types, "updated");
 
-  const truncated = rows.length > limit;
+  const [participantRows, sessionRows, accountRows] = await Promise.all([
+    wantsParticipants
+      ? db
+          .select({
+            createdAt: participant.createdAt,
+            updatedAt: participant.updatedAt,
+            firstName: profile.firstName,
+            lastName: profile.lastName,
+          })
+          .from(participant)
+          .innerJoin(profile, eq(participant.profileId, profile.id))
+          .where(
+            and(
+              isNull(participant.deletedAt),
+              isNull(profile.deletedAt),
+              filter.tournamentId
+                ? eq(participant.tournamentId, filter.tournamentId)
+                : undefined,
+              filter.from ? gte(participant.updatedAt, filter.from) : undefined,
+              // bound by createdAt, not updatedAt: a row edited after "to"
+              // must still contribute its in-range "registered" event
+              filter.to ? lte(participant.createdAt, filter.to) : undefined,
+            ),
+          )
+          .orderBy(desc(participant.updatedAt))
+          .limit(limit + 1)
+      : Promise.resolve([]),
+    wants(filter.types, "login")
+      ? db
+          .select({
+            createdAt: session.createdAt,
+            firstName: profile.firstName,
+            lastName: profile.lastName,
+          })
+          .from(session)
+          .innerJoin(profile, eq(session.userId, profile.userId))
+          .where(
+            and(
+              isNull(profile.deletedAt),
+              filter.from ? gte(session.createdAt, filter.from) : undefined,
+              filter.to ? lte(session.createdAt, filter.to) : undefined,
+            ),
+          )
+          .orderBy(desc(session.createdAt))
+          .limit(limit + 1)
+      : Promise.resolve([]),
+    wants(filter.types, "account_created")
+      ? db
+          .select({
+            createdAt: profile.createdAt,
+            firstName: profile.firstName,
+            lastName: profile.lastName,
+          })
+          .from(profile)
+          .where(
+            and(
+              isNull(profile.deletedAt),
+              filter.from ? gte(profile.createdAt, filter.from) : undefined,
+              filter.to ? lte(profile.createdAt, filter.to) : undefined,
+            ),
+          )
+          .orderBy(desc(profile.createdAt))
+          .limit(limit + 1)
+      : Promise.resolve([]),
+  ]);
+
+  const truncated =
+    participantRows.length > limit ||
+    sessionRows.length > limit ||
+    accountRows.length > limit;
+
+  const withName = <T extends { firstName: string; lastName: string }>(
+    row: T,
+  ) => ({ ...row, profileName: `${row.firstName} ${row.lastName}` });
 
   const events = buildActivityTimeline({
-    sessions: [],
-    participants: rows.slice(0, limit).map((r) => ({
-      createdAt: r.createdAt,
-      updatedAt: r.updatedAt,
-      tournamentName: r.tournamentName,
-      profileName: `${r.firstName} ${r.lastName}`,
-    })),
+    accounts: accountRows.slice(0, limit).map(withName),
+    sessions: sessionRows.slice(0, limit).map(withName),
+    participants: participantRows.slice(0, limit).map(withName),
   }).filter(
     (event) => wants(filter.types, event.type) && inRange(event.timestamp, filter),
   );

--- a/src/db/schema/pageView.ts
+++ b/src/db/schema/pageView.ts
@@ -1,0 +1,11 @@
+import { integer, pgTable, text } from "drizzle-orm/pg-core";
+import { timestamps } from "./columns.helpers";
+
+export const pageView = pgTable("page_view", {
+  id: integer("id").generatedAlwaysAsIdentity().primaryKey(),
+
+  userId: text("user_id").notNull(),
+  path: text("path").notNull(),
+
+  ...timestamps,
+});

--- a/src/db/schema/participantChangeLog.ts
+++ b/src/db/schema/participantChangeLog.ts
@@ -1,0 +1,17 @@
+import { integer, jsonb, pgTable } from "drizzle-orm/pg-core";
+import { timestamps } from "./columns.helpers";
+
+export type ParticipantChanges = Record<
+  string,
+  { old: unknown; new: unknown }
+>;
+
+export const participantChangeLog = pgTable("participant_change_log", {
+  id: integer("id").generatedAlwaysAsIdentity().primaryKey(),
+
+  profileId: integer("profile_id").notNull(),
+  tournamentId: integer("tournament_id").notNull(),
+  changes: jsonb("changes").$type<ParticipantChanges>().notNull(),
+
+  ...timestamps,
+});

--- a/src/lib/__tests__/activity.test.ts
+++ b/src/lib/__tests__/activity.test.ts
@@ -5,9 +5,7 @@ describe("buildActivityTimeline", () => {
   test("merges account, login and participant events sorted by timestamp descending", () => {
     const timeline = buildActivityTimeline({
       accountCreatedAt: new Date("2026-01-01T10:00:00Z"),
-      sessions: [
-        { createdAt: new Date("2026-01-05T09:00:00Z"), ipAddress: "1.2.3.4", userAgent: "Chrome" },
-      ],
+      sessions: [{ createdAt: new Date("2026-01-05T09:00:00Z") }],
       participants: [
         {
           createdAt: new Date("2026-01-02T10:00:00Z"),
@@ -22,7 +20,6 @@ describe("buildActivityTimeline", () => {
       "registered",
       "account_created",
     ]);
-    expect(timeline[0].detail).toBe("1.2.3.4 · Chrome");
   });
 
   test("emits an 'updated' event only when updatedAt meaningfully differs from createdAt", () => {

--- a/src/lib/__tests__/activity.test.ts
+++ b/src/lib/__tests__/activity.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "vitest";
+import { buildActivityTimeline } from "../activity";
+
+describe("buildActivityTimeline", () => {
+  test("merges account, login and participant events sorted by timestamp descending", () => {
+    const timeline = buildActivityTimeline({
+      accountCreatedAt: new Date("2026-01-01T10:00:00Z"),
+      sessions: [
+        { createdAt: new Date("2026-01-05T09:00:00Z"), ipAddress: "1.2.3.4", userAgent: "Chrome" },
+      ],
+      participants: [
+        {
+          createdAt: new Date("2026-01-02T10:00:00Z"),
+          updatedAt: new Date("2026-01-02T10:00:00Z"),
+          tournamentName: "Klubturnier 2026",
+        },
+      ],
+    });
+
+    expect(timeline.map((e) => e.type)).toEqual([
+      "login",
+      "registered",
+      "account_created",
+    ]);
+    expect(timeline[0].detail).toBe("1.2.3.4 · Chrome");
+  });
+
+  test("emits an 'updated' event only when updatedAt meaningfully differs from createdAt", () => {
+    const justRegistered = buildActivityTimeline({
+      sessions: [],
+      participants: [
+        {
+          createdAt: new Date("2026-01-02T10:00:00.000Z"),
+          updatedAt: new Date("2026-01-02T10:00:00.200Z"),
+          tournamentName: "Klubturnier 2026",
+        },
+      ],
+    });
+    expect(justRegistered.map((e) => e.type)).toEqual(["registered"]);
+
+    const laterEdited = buildActivityTimeline({
+      sessions: [],
+      participants: [
+        {
+          createdAt: new Date("2026-01-02T10:00:00.000Z"),
+          updatedAt: new Date("2026-01-03T08:00:00.000Z"),
+          tournamentName: "Klubturnier 2026",
+        },
+      ],
+    });
+    expect(laterEdited.map((e) => e.type)).toEqual(["updated", "registered"]);
+  });
+
+  test("returns an empty array when there is no activity", () => {
+    expect(buildActivityTimeline({ sessions: [], participants: [] })).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/activity.test.ts
+++ b/src/lib/__tests__/activity.test.ts
@@ -1,49 +1,60 @@
 import { describe, test, expect } from "vitest";
-import { buildActivityTimeline } from "../activity";
+import { buildActivityTimeline, computeParticipantChanges } from "../activity";
 
 describe("buildActivityTimeline", () => {
-  test("merges account, login and participant events sorted by timestamp descending", () => {
+  test("merges all event sources sorted by timestamp descending", () => {
     const timeline = buildActivityTimeline({
       accounts: [{ createdAt: new Date("2026-01-01T10:00:00Z") }],
       sessions: [{ createdAt: new Date("2026-01-05T09:00:00Z") }],
-      participants: [
+      registrations: [{ createdAt: new Date("2026-01-02T10:00:00Z") }],
+      changes: [
         {
-          createdAt: new Date("2026-01-02T10:00:00Z"),
-          updatedAt: new Date("2026-01-02T10:00:00Z"),
+          createdAt: new Date("2026-01-03T10:00:00Z"),
+          changes: { dwzRating: { old: 1850, new: 1870 } },
+        },
+      ],
+      pageViews: [
+        {
+          createdAt: new Date("2026-01-04T10:00:00Z"),
+          path: "/klubturnier-anmeldung",
         },
       ],
     });
 
     expect(timeline.map((e) => e.type)).toEqual([
       "login",
+      "page_view",
+      "updated",
       "registered",
       "account_created",
     ]);
-  });
-
-  test("emits an 'updated' event only when updatedAt meaningfully differs from createdAt", () => {
-    const justRegistered = buildActivityTimeline({
-      participants: [
-        {
-          createdAt: new Date("2026-01-02T10:00:00.000Z"),
-          updatedAt: new Date("2026-01-02T10:00:00.200Z"),
-        },
-      ],
-    });
-    expect(justRegistered.map((e) => e.type)).toEqual(["registered"]);
-
-    const laterEdited = buildActivityTimeline({
-      participants: [
-        {
-          createdAt: new Date("2026-01-02T10:00:00.000Z"),
-          updatedAt: new Date("2026-01-03T08:00:00.000Z"),
-        },
-      ],
-    });
-    expect(laterEdited.map((e) => e.type)).toEqual(["updated", "registered"]);
+    expect(timeline[1].path).toBe("/klubturnier-anmeldung");
+    expect(timeline[2].changes).toEqual({ dwzRating: { old: 1850, new: 1870 } });
   });
 
   test("returns an empty array when there is no activity", () => {
     expect(buildActivityTimeline({})).toEqual([]);
+  });
+});
+
+describe("computeParticipantChanges", () => {
+  test("captures only fields whose values actually differ", () => {
+    const changes = computeParticipantChanges(
+      { dwzRating: 1850, chessClub: "HSK", fideId: null },
+      { dwzRating: 1870, chessClub: "HSK", fideId: undefined },
+      ["dwzRating", "chessClub", "fideId"],
+    );
+
+    expect(changes).toEqual({ dwzRating: { old: 1850, new: 1870 } });
+  });
+
+  test("treats arrays as sets so reordering is not a change", () => {
+    const changes = computeParticipantChanges(
+      { secondaryMatchDays: ["tuesday", "friday"] },
+      { secondaryMatchDays: ["friday", "tuesday"] },
+      ["secondaryMatchDays"],
+    );
+
+    expect(changes).toEqual({});
   });
 });

--- a/src/lib/__tests__/activity.test.ts
+++ b/src/lib/__tests__/activity.test.ts
@@ -4,13 +4,12 @@ import { buildActivityTimeline } from "../activity";
 describe("buildActivityTimeline", () => {
   test("merges account, login and participant events sorted by timestamp descending", () => {
     const timeline = buildActivityTimeline({
-      accountCreatedAt: new Date("2026-01-01T10:00:00Z"),
+      accounts: [{ createdAt: new Date("2026-01-01T10:00:00Z") }],
       sessions: [{ createdAt: new Date("2026-01-05T09:00:00Z") }],
       participants: [
         {
           createdAt: new Date("2026-01-02T10:00:00Z"),
           updatedAt: new Date("2026-01-02T10:00:00Z"),
-          tournamentName: "Klubturnier 2026",
         },
       ],
     });
@@ -24,24 +23,20 @@ describe("buildActivityTimeline", () => {
 
   test("emits an 'updated' event only when updatedAt meaningfully differs from createdAt", () => {
     const justRegistered = buildActivityTimeline({
-      sessions: [],
       participants: [
         {
           createdAt: new Date("2026-01-02T10:00:00.000Z"),
           updatedAt: new Date("2026-01-02T10:00:00.200Z"),
-          tournamentName: "Klubturnier 2026",
         },
       ],
     });
     expect(justRegistered.map((e) => e.type)).toEqual(["registered"]);
 
     const laterEdited = buildActivityTimeline({
-      sessions: [],
       participants: [
         {
           createdAt: new Date("2026-01-02T10:00:00.000Z"),
           updatedAt: new Date("2026-01-03T08:00:00.000Z"),
-          tournamentName: "Klubturnier 2026",
         },
       ],
     });
@@ -49,6 +44,6 @@ describe("buildActivityTimeline", () => {
   });
 
   test("returns an empty array when there is no activity", () => {
-    expect(buildActivityTimeline({ sessions: [], participants: [] })).toEqual([]);
+    expect(buildActivityTimeline({})).toEqual([]);
   });
 });

--- a/src/lib/__tests__/activity.test.ts
+++ b/src/lib/__tests__/activity.test.ts
@@ -42,7 +42,6 @@ describe("computeParticipantChanges", () => {
     const changes = computeParticipantChanges(
       { dwzRating: 1850, chessClub: "HSK", fideId: null },
       { dwzRating: 1870, chessClub: "HSK", fideId: undefined },
-      ["dwzRating", "chessClub", "fideId"],
     );
 
     expect(changes).toEqual({ dwzRating: { old: 1850, new: 1870 } });
@@ -52,7 +51,6 @@ describe("computeParticipantChanges", () => {
     const changes = computeParticipantChanges(
       { secondaryMatchDays: ["tuesday", "friday"] },
       { secondaryMatchDays: ["friday", "tuesday"] },
-      ["secondaryMatchDays"],
     );
 
     expect(changes).toEqual({});

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -37,52 +37,50 @@ export function buildActivityTimeline(input: {
   }[];
   pageViews?: { createdAt: Date; path: string }[];
 }): ActivityEvent[] {
-  const events: ActivityEvent[] = [];
-
-  for (const account of input.accounts ?? []) {
-    events.push({ type: "account_created", timestamp: account.createdAt });
-  }
-
-  for (const session of input.sessions ?? []) {
-    events.push({ type: "login", timestamp: session.createdAt });
-  }
-
-  for (const registration of input.registrations ?? []) {
-    events.push({
-      type: "registered",
-      timestamp: registration.createdAt,
-      tournamentName: registration.tournamentName,
-    });
-  }
-
-  for (const change of input.changes ?? []) {
-    events.push({
-      type: "updated",
-      timestamp: change.createdAt,
-      changes: change.changes,
-      tournamentName: change.tournamentName,
-    });
-  }
-
-  for (const view of input.pageViews ?? []) {
-    events.push({
-      type: "page_view",
-      timestamp: view.createdAt,
-      path: view.path,
-    });
-  }
+  const events: ActivityEvent[] = [
+    ...(input.accounts ?? []).map(
+      ({ createdAt }): ActivityEvent => ({
+        type: "account_created",
+        timestamp: createdAt,
+      }),
+    ),
+    ...(input.sessions ?? []).map(
+      ({ createdAt }): ActivityEvent => ({ type: "login", timestamp: createdAt }),
+    ),
+    ...(input.registrations ?? []).map(
+      ({ createdAt, tournamentName }): ActivityEvent => ({
+        type: "registered",
+        timestamp: createdAt,
+        tournamentName,
+      }),
+    ),
+    ...(input.changes ?? []).map(
+      ({ createdAt, changes, tournamentName }): ActivityEvent => ({
+        type: "updated",
+        timestamp: createdAt,
+        changes,
+        tournamentName,
+      }),
+    ),
+    ...(input.pageViews ?? []).map(
+      ({ createdAt, path }): ActivityEvent => ({
+        type: "page_view",
+        timestamp: createdAt,
+        path,
+      }),
+    ),
+  ];
 
   return events.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
 }
 
-export function computeParticipantChanges<T extends Record<string, unknown>>(
-  oldValues: T,
-  newValues: Partial<Record<keyof T, unknown>>,
-  fields: (keyof T & string)[],
+export function computeParticipantChanges(
+  oldValues: Record<string, unknown>,
+  newValues: Record<string, unknown>,
 ): ParticipantChanges {
   const changes: ParticipantChanges = {};
 
-  for (const field of fields) {
+  for (const field of Object.keys(newValues)) {
     const oldValue = normalize(oldValues[field]);
     const newValue = normalize(newValues[field]);
     if (JSON.stringify(oldValue) !== JSON.stringify(newValue)) {

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -23,13 +23,18 @@ export type ActivityEvent = {
   timestamp: Date;
   path?: string;
   changes?: ParticipantChanges;
+  tournamentName?: string;
 };
 
 export function buildActivityTimeline(input: {
   accounts?: { createdAt: Date }[];
   sessions?: { createdAt: Date }[];
-  registrations?: { createdAt: Date }[];
-  changes?: { createdAt: Date; changes: ParticipantChanges }[];
+  registrations?: { createdAt: Date; tournamentName?: string }[];
+  changes?: {
+    createdAt: Date;
+    changes: ParticipantChanges;
+    tournamentName?: string;
+  }[];
   pageViews?: { createdAt: Date; path: string }[];
 }): ActivityEvent[] {
   const events: ActivityEvent[] = [];
@@ -43,7 +48,11 @@ export function buildActivityTimeline(input: {
   }
 
   for (const registration of input.registrations ?? []) {
-    events.push({ type: "registered", timestamp: registration.createdAt });
+    events.push({
+      type: "registered",
+      timestamp: registration.createdAt,
+      tournamentName: registration.tournamentName,
+    });
   }
 
   for (const change of input.changes ?? []) {
@@ -51,6 +60,7 @@ export function buildActivityTimeline(input: {
       type: "updated",
       timestamp: change.createdAt,
       changes: change.changes,
+      tournamentName: change.tournamentName,
     });
   }
 

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -17,7 +17,6 @@ export const ACTIVITY_EVENT_LABELS: Record<ActivityEventType, string> = {
 export type ActivityEvent = {
   type: ActivityEventType;
   timestamp: Date;
-  tournamentName?: string;
   profileName?: string;
 };
 
@@ -27,30 +26,36 @@ export type ActivityEvent = {
 const MIN_EDIT_GAP_MS = 1000;
 
 export function buildActivityTimeline(input: {
-  accountCreatedAt?: Date | null;
-  sessions: { createdAt: Date }[];
-  participants: {
+  accounts?: { createdAt: Date; profileName?: string }[];
+  sessions?: { createdAt: Date; profileName?: string }[];
+  participants?: {
     createdAt: Date;
     updatedAt: Date;
-    tournamentName: string;
     profileName?: string;
   }[];
 }): ActivityEvent[] {
   const events: ActivityEvent[] = [];
 
-  if (input.accountCreatedAt) {
-    events.push({ type: "account_created", timestamp: input.accountCreatedAt });
+  for (const account of input.accounts ?? []) {
+    events.push({
+      type: "account_created",
+      timestamp: account.createdAt,
+      profileName: account.profileName,
+    });
   }
 
-  for (const session of input.sessions) {
-    events.push({ type: "login", timestamp: session.createdAt });
+  for (const session of input.sessions ?? []) {
+    events.push({
+      type: "login",
+      timestamp: session.createdAt,
+      profileName: session.profileName,
+    });
   }
 
-  for (const p of input.participants) {
+  for (const p of input.participants ?? []) {
     events.push({
       type: "registered",
       timestamp: p.createdAt,
-      tournamentName: p.tournamentName,
       profileName: p.profileName,
     });
 
@@ -58,7 +63,6 @@ export function buildActivityTimeline(input: {
       events.push({
         type: "updated",
         timestamp: p.updatedAt,
-        tournamentName: p.tournamentName,
         profileName: p.profileName,
       });
     }

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,8 +1,11 @@
+import type { ParticipantChanges } from "@/db/schema/participantChangeLog";
+
 export const ACTIVITY_EVENT_TYPES = [
   "account_created",
   "login",
   "registered",
   "updated",
+  "page_view",
 ] as const;
 
 export type ActivityEventType = (typeof ACTIVITY_EVENT_TYPES)[number];
@@ -12,61 +15,80 @@ export const ACTIVITY_EVENT_LABELS: Record<ActivityEventType, string> = {
   login: "Login",
   registered: "Turnier angemeldet",
   updated: "Turnier-Daten geändert",
+  page_view: "Seite geöffnet",
 };
 
 export type ActivityEvent = {
   type: ActivityEventType;
   timestamp: Date;
-  profileName?: string;
+  path?: string;
+  changes?: ParticipantChanges;
 };
 
-// A participant row's updatedAt is set to (roughly) createdAt on insert, so a
-// gap below this threshold means "never actually edited", not "edited
-// instantly after registering".
-const MIN_EDIT_GAP_MS = 1000;
-
 export function buildActivityTimeline(input: {
-  accounts?: { createdAt: Date; profileName?: string }[];
-  sessions?: { createdAt: Date; profileName?: string }[];
-  participants?: {
-    createdAt: Date;
-    updatedAt: Date;
-    profileName?: string;
-  }[];
+  accounts?: { createdAt: Date }[];
+  sessions?: { createdAt: Date }[];
+  registrations?: { createdAt: Date }[];
+  changes?: { createdAt: Date; changes: ParticipantChanges }[];
+  pageViews?: { createdAt: Date; path: string }[];
 }): ActivityEvent[] {
   const events: ActivityEvent[] = [];
 
   for (const account of input.accounts ?? []) {
-    events.push({
-      type: "account_created",
-      timestamp: account.createdAt,
-      profileName: account.profileName,
-    });
+    events.push({ type: "account_created", timestamp: account.createdAt });
   }
 
   for (const session of input.sessions ?? []) {
+    events.push({ type: "login", timestamp: session.createdAt });
+  }
+
+  for (const registration of input.registrations ?? []) {
+    events.push({ type: "registered", timestamp: registration.createdAt });
+  }
+
+  for (const change of input.changes ?? []) {
     events.push({
-      type: "login",
-      timestamp: session.createdAt,
-      profileName: session.profileName,
+      type: "updated",
+      timestamp: change.createdAt,
+      changes: change.changes,
     });
   }
 
-  for (const p of input.participants ?? []) {
+  for (const view of input.pageViews ?? []) {
     events.push({
-      type: "registered",
-      timestamp: p.createdAt,
-      profileName: p.profileName,
+      type: "page_view",
+      timestamp: view.createdAt,
+      path: view.path,
     });
-
-    if (p.updatedAt.getTime() - p.createdAt.getTime() > MIN_EDIT_GAP_MS) {
-      events.push({
-        type: "updated",
-        timestamp: p.updatedAt,
-        profileName: p.profileName,
-      });
-    }
   }
 
   return events.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+}
+
+export function computeParticipantChanges<T extends Record<string, unknown>>(
+  oldValues: T,
+  newValues: Partial<Record<keyof T, unknown>>,
+  fields: (keyof T & string)[],
+): ParticipantChanges {
+  const changes: ParticipantChanges = {};
+
+  for (const field of fields) {
+    const oldValue = normalize(oldValues[field]);
+    const newValue = normalize(newValues[field]);
+    if (JSON.stringify(oldValue) !== JSON.stringify(newValue)) {
+      changes[field] = { old: oldValue, new: newValue };
+    }
+  }
+
+  return changes;
+}
+
+function normalize(value: unknown): unknown {
+  if (value == null) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return [...value].sort();
+  }
+  return value;
 }

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -17,7 +17,6 @@ export const ACTIVITY_EVENT_LABELS: Record<ActivityEventType, string> = {
 export type ActivityEvent = {
   type: ActivityEventType;
   timestamp: Date;
-  detail?: string;
   tournamentName?: string;
   profileName?: string;
 };
@@ -29,7 +28,7 @@ const MIN_EDIT_GAP_MS = 1000;
 
 export function buildActivityTimeline(input: {
   accountCreatedAt?: Date | null;
-  sessions: { createdAt: Date; ipAddress: string | null; userAgent: string | null }[];
+  sessions: { createdAt: Date }[];
   participants: {
     createdAt: Date;
     updatedAt: Date;
@@ -44,14 +43,7 @@ export function buildActivityTimeline(input: {
   }
 
   for (const session of input.sessions) {
-    const detailParts = [session.ipAddress, session.userAgent].filter(
-      (part): part is string => Boolean(part),
-    );
-    events.push({
-      type: "login",
-      timestamp: session.createdAt,
-      detail: detailParts.length > 0 ? detailParts.join(" · ") : undefined,
-    });
+    events.push({ type: "login", timestamp: session.createdAt });
   }
 
   for (const p of input.participants) {

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,0 +1,76 @@
+export const ACTIVITY_EVENT_TYPES = [
+  "account_created",
+  "login",
+  "registered",
+  "updated",
+] as const;
+
+export type ActivityEventType = (typeof ACTIVITY_EVENT_TYPES)[number];
+
+export const ACTIVITY_EVENT_LABELS: Record<ActivityEventType, string> = {
+  account_created: "Konto erstellt",
+  login: "Login",
+  registered: "Turnier angemeldet",
+  updated: "Turnier-Daten geändert",
+};
+
+export type ActivityEvent = {
+  type: ActivityEventType;
+  timestamp: Date;
+  detail?: string;
+  tournamentName?: string;
+  profileName?: string;
+};
+
+// A participant row's updatedAt is set to (roughly) createdAt on insert, so a
+// gap below this threshold means "never actually edited", not "edited
+// instantly after registering".
+const MIN_EDIT_GAP_MS = 1000;
+
+export function buildActivityTimeline(input: {
+  accountCreatedAt?: Date | null;
+  sessions: { createdAt: Date; ipAddress: string | null; userAgent: string | null }[];
+  participants: {
+    createdAt: Date;
+    updatedAt: Date;
+    tournamentName: string;
+    profileName?: string;
+  }[];
+}): ActivityEvent[] {
+  const events: ActivityEvent[] = [];
+
+  if (input.accountCreatedAt) {
+    events.push({ type: "account_created", timestamp: input.accountCreatedAt });
+  }
+
+  for (const session of input.sessions) {
+    const detailParts = [session.ipAddress, session.userAgent].filter(
+      (part): part is string => Boolean(part),
+    );
+    events.push({
+      type: "login",
+      timestamp: session.createdAt,
+      detail: detailParts.length > 0 ? detailParts.join(" · ") : undefined,
+    });
+  }
+
+  for (const p of input.participants) {
+    events.push({
+      type: "registered",
+      timestamp: p.createdAt,
+      tournamentName: p.tournamentName,
+      profileName: p.profileName,
+    });
+
+    if (p.updatedAt.getTime() - p.createdAt.getTime() > MIN_EDIT_GAP_MS) {
+      events.push({
+        type: "updated",
+        timestamp: p.updatedAt,
+        tournamentName: p.tournamentName,
+        profileName: p.profileName,
+      });
+    }
+  }
+
+  return events.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -26,6 +26,16 @@ export function isValidDateOnly(date: string): boolean {
   return /^\d{4}-\d{2}-\d{2}$/.test(date) && parseDateOnly(date).isValid;
 }
 
+export function dateOnlyRange(
+  from?: string,
+  to?: string,
+): { from?: Date; to?: Date } {
+  return {
+    from: from ? parseDateOnly(from).toJSDate() : undefined,
+    to: to ? parseDateOnly(to).endOf("day").toJSDate() : undefined,
+  };
+}
+
 export function utcDateToDateOnly(date: Date): string {
   return date.toISOString().slice(0, 10);
 }


### PR DESCRIPTION
## Zusammenfassung

Neue Admin-Seite „Verlauf" (`/turniere/[slug]/admin/logging`), auf der Admins die Aktivität einzelner Nutzer turnierübergreifend einsehen können: Konto-Erstellung, Logins, Turnier-Anmeldungen, Änderungen an Anmeldedaten (mit Feld-Diffs) und Seitenaufrufe.

### Datenmodell (Migration `0029`)
- **`participant_change_log`**: protokolliert Feld-Änderungen an Turnier-Anmeldungen als JSONB-Diff (`{ feld: { old, new } }`), geschrieben transaktional zusammen mit dem Update
- **`page_view`**: Seitenaufrufe eingeloggter Nutzer (`userId`, `path`), getrackt über einen leichtgewichtigen Client-Tracker im Root-Layout

### Kernstücke
- `src/lib/activity.ts`: Event-Typen mit deutschen Labels, `buildActivityTimeline` (merged + sortiert alle Quellen), `computeParticipantChanges` (normalisierter Feld-Diff, Arrays als Mengen)
- `src/db/repositories/activity.ts`: lädt nur die gefilterten Event-Typen parallel, mit Zeitraum-Filter und Truncation-Erkennung (Limit 200 pro Quelle)
- Filter-UI mit Nutzer-Combobox, Aktionstyp-Toggles und Von/Bis-Datumsfeldern (URL-State via Search-Params)
- Aufklappbare Feld-Diffs in der Tabelle mit deutschen Feld-Labels und formatierten Werten
- Verlauf-Button pro Nutzer in der Admin-Nutzerverwaltung

### Tests
- Unit-Tests für `buildActivityTimeline` und `computeParticipantChanges`
- `bun run lint`, `bun x tsc --noEmit` und `bun run test` (92/92) grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)